### PR TITLE
(feat) Set up two GraphQL servers (public and admin) with a shared schema

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -1,0 +1,6 @@
+type Query {
+    """
+    Test Prospect Curation API - Admin side
+    """
+    helloProspectCurationAdmin: PCTest!
+}

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -1,0 +1,6 @@
+type Query {
+    """
+    Test Prospect Curation API
+    """
+    helloProspectCuration: PCTest!
+}

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -1,0 +1,5 @@
+"""
+A test string
+"""
+scalar PCTest
+

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -1,0 +1,5 @@
+export const resolvers = {
+  Query: {
+    helloProspectCurationAdmin: () => 'Hello Prospect Curation Admin API',
+  },
+};

--- a/src/admin/server.ts
+++ b/src/admin/server.ts
@@ -1,0 +1,30 @@
+import { ApolloServer } from 'apollo-server-express';
+import { buildFederatedSchema } from '@apollo/federation';
+import { typeDefsAdmin } from '../typeDefs';
+import { resolvers as resolversAdmin } from './resolvers';
+import responseCachePlugin from 'apollo-server-plugin-response-cache';
+import { GraphQLRequestContext } from 'apollo-server-types';
+import { sentryPlugin } from '@pocket-tools/apollo-utils';
+import { ApolloServerPluginLandingPageGraphQLPlayground } from 'apollo-server-core';
+
+export const server = new ApolloServer({
+  schema: buildFederatedSchema([
+    { typeDefs: typeDefsAdmin, resolvers: resolversAdmin },
+  ]),
+  plugins: [
+    //Copied from Apollo docs, the sessionID signifies if we should seperate out caches by user.
+    responseCachePlugin({
+      //https://www.apollographql.com/docs/apollo-server/performance/caching/#saving-full-responses-to-a-cache
+      //The user id is added to the request header by the apollo gateway (client api)
+      sessionId: (requestContext: GraphQLRequestContext) =>
+        requestContext?.request?.http?.headers?.has('userId')
+          ? requestContext?.request?.http?.headers?.get('userId')
+          : null,
+    }),
+    sentryPlugin,
+    ApolloServerPluginLandingPageGraphQLPlayground(),
+  ],
+  context: {
+    // TODO: add DB client
+  },
+});

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,0 +1,5 @@
+export const resolvers = {
+  Query: {
+    helloProspectCuration: () => 'Hello, World!',
+  },
+};

--- a/src/public/server.ts
+++ b/src/public/server.ts
@@ -1,0 +1,30 @@
+import { ApolloServer } from 'apollo-server-express';
+import { buildFederatedSchema } from '@apollo/federation';
+import { typeDefsPublic } from '../typeDefs';
+import { resolvers as resolversPublic } from './resolvers';
+import responseCachePlugin from 'apollo-server-plugin-response-cache';
+import { GraphQLRequestContext } from 'apollo-server-types';
+import { sentryPlugin } from '@pocket-tools/apollo-utils';
+import { ApolloServerPluginLandingPageGraphQLPlayground } from 'apollo-server-core';
+
+export const server = new ApolloServer({
+  schema: buildFederatedSchema([
+    { typeDefs: typeDefsPublic, resolvers: resolversPublic },
+  ]),
+  plugins: [
+    //Copied from Apollo docs, the sessionID signifies if we should seperate out caches by user.
+    responseCachePlugin({
+      //https://www.apollographql.com/docs/apollo-server/performance/caching/#saving-full-responses-to-a-cache
+      //The user id is added to the request header by the apollo gateway (client api)
+      sessionId: (requestContext: GraphQLRequestContext) =>
+        requestContext?.request?.http?.headers?.has('userId')
+          ? requestContext?.request?.http?.headers?.get('userId')
+          : null,
+    }),
+    sentryPlugin,
+    ApolloServerPluginLandingPageGraphQLPlayground(),
+  ],
+  context: {
+    // TODO: add DB client
+  },
+});

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,5 +1,0 @@
-export const resolvers = {
-  Query: {
-    hello: () => 'Hello, World!',
-  },
-};

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -2,6 +2,20 @@ import path from 'path';
 import fs from 'fs';
 import { gql } from 'apollo-server';
 
-export default gql(
-  fs.readFileSync(path.join(__dirname, '..', 'schema.graphql')).toString()
+const sharedSchema = fs
+  .readFileSync(path.join(__dirname, '..', 'schema-shared.graphql'))
+  .toString();
+
+export const typeDefsPublic = gql(
+  fs
+    .readFileSync(path.join(__dirname, '..', 'schema-public.graphql'))
+    .toString()
+    .concat(sharedSchema)
+);
+
+export const typeDefsAdmin = gql(
+  fs
+    .readFileSync(path.join(__dirname, '..', 'schema-admin.graphql'))
+    .toString()
+    .concat(sharedSchema)
 );


### PR DESCRIPTION
## Goal

Do the necessary prep work before work on this project starts - we know we will need two APIs, one public and one for the internal tool (`admin`).

## I'd love feedback/perspectives on:
- Why I'm getting a flood of AWS Xray warnings in the console. 

## Implementation Decisions

- Modelling on work done in `collection-api`, split the GraphQL schema in three
- public, admin and shared. Added a test scalar type in the shared schema and
a query each in the public and admin schemas returning the shared scalar type.

- Test drove the default Apollo Sandbox - did not like it, enabled the old
GraphQL Playground which is now a plugin.

- Noticed that the paths for public and admin servers were not being applied
at the time of launching the web servers - the default /graphql was being used
instead. Fixed by placing all the relevant code inside an async function.


