### PR TITLE
chore(deps) Remove unused packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,7 @@
         "@prisma/client": "^3.4.1",
         "@sentry/node": "^6.14.1",
         "@sentry/tracing": "^6.14.0",
-        "apollo-client": "^2.6.10",
         "apollo-datasource-rest": "^3.3.0",
-        "apollo-link": "^1.2.14",
-        "apollo-link-rest": "^0.8.0-beta.0",
         "apollo-server": "^3.4.1",
         "apollo-server-cache-redis": "^3.2.0",
         "apollo-server-express": "^3.4.1",
@@ -50,38 +47,6 @@
         "ts-jest": "^27.0.7",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4"
-      }
-    },
-    "node_modules/@apollo/client": {
-      "version": "3.4.8",
-      "integrity": "sha512-/cNqTSwc2Dw8q6FDDjdd30+yvhP7rI0Fvl3Hbro0lTtFuhzkevfNyQaI2jAiOrjU6Jc0RbanxULaNrX7UmvjSQ==",
-      "peer": true,
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.0.0",
-        "@wry/context": "^0.6.0",
-        "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
-        "graphql-tag": "^2.12.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
-        "prop-types": "^15.7.2",
-        "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.9.0",
-        "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "subscriptions-transport-ws": "^0.9.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "subscriptions-transport-ws": {
-          "optional": true
-        }
       }
     },
     "node_modules/@apollo/federation": {
@@ -828,14 +793,6 @@
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-typed-document-node/core": {
-      "version": "3.1.0",
-      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
-      "peer": true,
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1820,39 +1777,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@wry/context": {
-      "version": "0.6.1",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wry/equality": {
-      "version": "0.5.2",
-      "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wry/trie": {
-      "version": "0.3.1",
-      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -2174,16 +2098,6 @@
       },
       "peerDependencies": {
         "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-link-rest": {
-      "version": "0.8.0-beta.0",
-      "integrity": "sha512-+/cHVXz0jF4SOg3bIVPxCArnpp7ojwhLarT9MLzbAuoaI+Uq+pU9Ob8Xmq4BS3Z+mIdVmnrIyw8EvqEzP7RL0w==",
-      "peerDependencies": {
-        "@apollo/client": ">=3",
-        "graphql": ">=0.11",
-        "graphql-anywhere": ">=4",
-        "qs": ">=6"
       }
     },
     "node_modules/apollo-link/node_modules/ts-invariant": {
@@ -2583,12 +2497,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/backo2": {
-      "version": "1.0.2",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
@@ -2807,18 +2715,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.2",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "peer": true,
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3830,12 +3726,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4156,7 +4046,8 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -4186,19 +4077,6 @@
       "dev": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "peer": true,
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-package-type": {
@@ -4391,6 +4269,7 @@
     "node_modules/has": {
       "version": "1.0.3",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -4405,31 +4284,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.0.2",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-yarn": {
       "version": "2.1.0",
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "peer": true,
-      "dependencies": {
-        "react-is": "^16.7.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -4841,12 +4701,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/iterall": {
-      "version": "1.3.0",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/jest": {
       "version": "27.3.1",
@@ -5479,7 +5333,8 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -5709,17 +5564,6 @@
     "node_modules/long": {
       "version": "4.0.0",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
@@ -6093,14 +5937,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/object-inspect": {
-      "version": "1.11.0",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
@@ -6132,15 +5968,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/optimism": {
-      "version": "0.16.1",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
-      "peer": true,
-      "dependencies": {
-        "@wry/context": "^0.6.0",
-        "@wry/trie": "^0.3.0"
       }
     },
     "node_modules/optionator": {
@@ -6444,16 +6271,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.7.2",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "node_modules/propagate": {
       "version": "2.0.1",
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
@@ -6510,20 +6327,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.10.1",
-      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
-      "peer": true,
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -6609,11 +6412,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "peer": true
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -6955,19 +6753,6 @@
       "version": "1.2.1",
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
-    "node_modules/side-channel": {
-      "version": "1.0.4",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/signal-exit": {
       "version": "3.0.3",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
@@ -7149,31 +6934,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/subscriptions-transport-ws": {
-      "version": "0.9.19",
-      "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependencies": {
-        "graphql": ">=0.10.0"
-      }
-    },
-    "node_modules/subscriptions-transport-ws/node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -7195,14 +6955,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "4.0.0",
-      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/symbol-tree": {
@@ -7323,17 +7075,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ts-invariant": {
-      "version": "0.9.1",
-      "integrity": "sha512-hSeYibh29ULlHkuEfukcoiyTct+s2RzczMLTv4x3NWC/YrBy7x7ps5eYq/b4Y3Sb9/uAlf54+/5CAEMVxPhuQw==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=8"
@@ -7797,7 +7538,7 @@
     "node_modules/ws": {
       "version": "7.5.3",
       "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -7898,37 +7639,9 @@
     "node_modules/zen-observable": {
       "version": "0.8.15",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "node_modules/zen-observable-ts": {
-      "version": "1.1.0",
-      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
-      "peer": true,
-      "dependencies": {
-        "@types/zen-observable": "0.8.3",
-        "zen-observable": "0.8.15"
-      }
     }
   },
   "dependencies": {
-    "@apollo/client": {
-      "version": "3.4.8",
-      "integrity": "sha512-/cNqTSwc2Dw8q6FDDjdd30+yvhP7rI0Fvl3Hbro0lTtFuhzkevfNyQaI2jAiOrjU6Jc0RbanxULaNrX7UmvjSQ==",
-      "peer": true,
-      "requires": {
-        "@graphql-typed-document-node/core": "^3.0.0",
-        "@wry/context": "^0.6.0",
-        "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
-        "graphql-tag": "^2.12.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
-        "prop-types": "^15.7.2",
-        "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.9.0",
-        "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.1.0"
-      }
-    },
     "@apollo/federation": {
       "version": "0.33.6",
       "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.33.6.tgz",
@@ -8479,12 +8192,6 @@
       "requires": {
         "tslib": "~2.3.0"
       }
-    },
-    "@graphql-typed-document-node/core": {
-      "version": "3.1.0",
-      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
-      "peer": true,
-      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.6.0",
@@ -9294,30 +9001,6 @@
         "eslint-visitor-keys": "^3.0.0"
       }
     },
-    "@wry/context": {
-      "version": "0.6.1",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@wry/equality": {
-      "version": "0.5.2",
-      "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@wry/trie": {
-      "version": "0.3.1",
-      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -9581,11 +9264,6 @@
           }
         }
       }
-    },
-    "apollo-link-rest": {
-      "version": "0.8.0-beta.0",
-      "integrity": "sha512-+/cHVXz0jF4SOg3bIVPxCArnpp7ojwhLarT9MLzbAuoaI+Uq+pU9Ob8Xmq4BS3Z+mIdVmnrIyw8EvqEzP7RL0w==",
-      "requires": {}
     },
     "apollo-reporting-protobuf": {
       "version": "3.1.0",
@@ -9876,12 +9554,6 @@
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
-    "backo2": {
-      "version": "1.0.2",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "optional": true,
-      "peer": true
-    },
     "balanced-match": {
       "version": "1.0.2",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
@@ -10051,15 +9723,6 @@
           "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
           "dev": true
         }
-      }
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "peer": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
       }
     },
     "callsites": {
@@ -10806,12 +10469,6 @@
       "version": "1.8.1",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "optional": true,
-      "peer": true
-    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -11073,7 +10730,8 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -11095,16 +10753,6 @@
       "version": "2.0.0",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
-    },
-    "get-intrinsic": {
-      "version": "1.1.1",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "peer": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -11243,6 +10891,7 @@
     "has": {
       "version": "1.0.3",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -11251,23 +10900,10 @@
       "version": "4.0.0",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
-    "has-symbols": {
-      "version": "1.0.2",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "peer": true
-    },
     "has-yarn": {
       "version": "2.1.0",
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "peer": true,
-      "requires": {
-        "react-is": "^16.7.0"
-      }
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -11565,12 +11201,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "iterall": {
-      "version": "1.3.0",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "optional": true,
-      "peer": true
     },
     "jest": {
       "version": "27.3.1",
@@ -12073,7 +11703,8 @@
     },
     "js-tokens": {
       "version": "4.0.0",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -12255,14 +11886,6 @@
     "long": {
       "version": "4.0.0",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -12544,11 +12167,6 @@
       "version": "4.1.1",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
-    "object-inspect": {
-      "version": "1.11.0",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "peer": true
-    },
     "on-finished": {
       "version": "2.3.0",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
@@ -12571,15 +12189,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "optimism": {
-      "version": "0.16.1",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
-      "peer": true,
-      "requires": {
-        "@wry/context": "^0.6.0",
-        "@wry/trie": "^0.3.0"
       }
     },
     "optionator": {
@@ -12789,16 +12398,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "propagate": {
       "version": "2.0.1",
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
@@ -12843,14 +12442,6 @@
       "dev": true,
       "requires": {
         "escape-goat": "^2.0.0"
-      }
-    },
-    "qs": {
-      "version": "6.10.1",
-      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
-      "peer": true,
-      "requires": {
-        "side-channel": "^1.0.4"
       }
     },
     "queue-microtask": {
@@ -12911,11 +12502,6 @@
           "dev": true
         }
       }
-    },
-    "react-is": {
-      "version": "16.13.1",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "peer": true
     },
     "readdirp": {
       "version": "3.6.0",
@@ -13166,16 +12752,6 @@
       "version": "1.2.1",
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
-    "side-channel": {
-      "version": "1.0.4",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      }
-    },
     "signal-exit": {
       "version": "3.0.3",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
@@ -13318,27 +12894,6 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
-    "subscriptions-transport-ws": {
-      "version": "0.9.19",
-      "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "dependencies": {
-        "symbol-observable": {
-          "version": "1.2.0",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "supports-color": {
       "version": "7.2.0",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -13355,11 +12910,6 @@
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
       }
-    },
-    "symbol-observable": {
-      "version": "4.0.0",
-      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-      "peer": true
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -13452,14 +13002,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.1"
-      }
-    },
-    "ts-invariant": {
-      "version": "0.9.1",
-      "integrity": "sha512-hSeYibh29ULlHkuEfukcoiyTct+s2RzczMLTv4x3NWC/YrBy7x7ps5eYq/b4Y3Sb9/uAlf54+/5CAEMVxPhuQw==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.1.0"
       }
     },
     "ts-jest": {
@@ -13789,7 +13331,7 @@
     "ws": {
       "version": "7.5.3",
       "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {}
     },
     "xdg-basedir": {
@@ -13855,15 +13397,6 @@
     "zen-observable": {
       "version": "0.8.15",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "zen-observable-ts": {
-      "version": "1.1.0",
-      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
-      "peer": true,
-      "requires": {
-        "@types/zen-observable": "0.8.3",
-        "zen-observable": "0.8.15"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "nodemonConfig": {
     "watch": [
-      "*.*", "*.graphql"
+      "*.*",
+      "*.graphql"
     ]
   },
   "prisma": {
@@ -45,10 +46,7 @@
     "@prisma/client": "^3.4.1",
     "@sentry/node": "^6.14.1",
     "@sentry/tracing": "^6.14.0",
-    "apollo-client": "^2.6.10",
     "apollo-datasource-rest": "^3.3.0",
-    "apollo-link": "^1.2.14",
-    "apollo-link-rest": "^0.8.0-beta.0",
     "apollo-server": "^3.4.1",
     "apollo-server-cache-redis": "^3.2.0",
     "apollo-server-express": "^3.4.1",


### PR DESCRIPTION
## Goal

Removed Apollo Client v.2, `apollo-link` and `apollo-link-rest` packages.

There is no need for these packages in this repository. What's more, they have not been updated in many months and they're blocking an upgrade from `graphql@15` to `graphql@16` (more info here: https://github.com/Pocket/curated-corpus-api/pull/184#pullrequestreview-799600371). 
