### PR TITLE
chore(errors): Use custom Apollo Server errors

### DIFF
--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -109,9 +109,10 @@ describe('mutations: ApprovedItem', () => {
 
       // And there is the right error from the resolvers
       if (result.errors) {
-        expect(result.errors[0].message).to.equal(
+        expect(result.errors[0].message).to.contain(
           `An approved item with the URL "${input.url}" already exists`
         );
+        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
       }
 
       // Check that the ADD_ITEM event was not fired
@@ -196,9 +197,10 @@ describe('mutations: ApprovedItem', () => {
 
       // And there is the right error from the resolvers
       if (result.errors) {
-        expect(result.errors[0].message).to.equal(
+        expect(result.errors[0].message).to.contain(
           `Cannot create a scheduled entry with New Tab GUID of "${input.newTabGuid}".`
         );
+        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
       }
 
       // Check that the ADD_ITEM event was not fired
@@ -301,9 +303,10 @@ describe('mutations: ApprovedItem', () => {
 
       // And there is the right error from the resolvers
       if (result.errors) {
-        expect(result.errors[0].message).to.equal(
+        expect(result.errors[0].message).to.contain(
           `An approved item with the URL "${input.url}" already exists`
         );
+        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
       }
 
       // Check that the UPDATE_ITEM event was not fired

--- a/src/admin/resolvers/mutations/ApprovedItem.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.ts
@@ -13,6 +13,7 @@ import {
   newTabAllowedValues,
   ApprovedItemS3ImageUrl,
 } from '../../../shared/types';
+import { UserInputError } from 'apollo-server';
 
 /**
  * Creates an approved curated item with data supplied. Optionally, schedules the freshly
@@ -35,7 +36,7 @@ export async function createApprovedItem(
     newTabGuid &&
     !newTabAllowedValues.includes(newTabGuid)
   ) {
-    throw new Error(
+    throw new UserInputError(
       `Cannot create a scheduled entry with New Tab GUID of "${data.newTabGuid}".`
     );
   }

--- a/src/admin/resolvers/mutations/RejectedItem.integration.ts
+++ b/src/admin/resolvers/mutations/RejectedItem.integration.ts
@@ -93,9 +93,10 @@ describe('mutations: RejectedItem', () => {
 
       // And there is the right error from the resolvers
       if (result.errors) {
-        expect(result.errors[0].message).to.equal(
+        expect(result.errors[0].message).to.contain(
           `A rejected item with the URL "${input.url}" already exists`
         );
+        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
       }
 
       // Check that the REJECT_ITEM event was not fired

--- a/src/admin/resolvers/mutations/ScheduledItem.integration.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.integration.ts
@@ -18,7 +18,7 @@ import { getUnixTimestamp } from '../fields/UnixTimestamp';
 import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
 import { ScheduledCorpusItemEventType } from '../../../events/types';
 
-describe('mutations: NewTabFeedSchedule', () => {
+describe('mutations: ScheduledItem', () => {
   const eventEmitter = new CuratedCorpusEventEmitter();
   const server = getServer(eventEmitter);
 
@@ -60,9 +60,10 @@ describe('mutations: NewTabFeedSchedule', () => {
 
       // And there is the correct error from the resolvers
       if (result.errors) {
-        expect(result.errors[0].message).to.equal(
+        expect(result.errors[0].message).to.contain(
           `Cannot create a scheduled entry with New Tab GUID of "RECSAPI".`
         );
+        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
       }
 
       // Check that the ADD_SCHEDULE event was not fired
@@ -89,8 +90,11 @@ describe('mutations: NewTabFeedSchedule', () => {
 
       // And there is the correct error from the resolvers
       if (result.errors) {
-        expect(result.errors[0].message).to.equal(
+        expect(result.errors[0].message).to.contain(
           `Cannot create a scheduled entry: Approved Item with id "not-a-valid-id-at-all" does not exist.`
+        );
+        expect(result.errors[0].extensions?.code).to.equal(
+          'INTERNAL_SERVER_ERROR'
         );
       }
 
@@ -182,8 +186,11 @@ describe('mutations: NewTabFeedSchedule', () => {
 
       // And there is the correct error from the resolvers
       if (result.errors) {
-        expect(result.errors[0].message).to.equal(
+        expect(result.errors[0].message).to.contain(
           `Item with ID of '${input.externalId}' could not be found.`
+        );
+        expect(result.errors[0].extensions?.code).to.equal(
+          'INTERNAL_SERVER_ERROR'
         );
       }
 

--- a/src/admin/resolvers/mutations/ScheduledItem.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.ts
@@ -5,6 +5,7 @@ import {
 import { ScheduledItem } from '../../../database/types';
 import { newTabAllowedValues } from '../../../shared/types';
 import { ScheduledCorpusItemEventType } from '../../../events/types';
+import { UserInputError } from 'apollo-server';
 
 /**
  * Deletes an item from the New Tab schedule.
@@ -34,7 +35,7 @@ export async function createScheduledItem(
   context
 ): Promise<ScheduledItem> {
   if (!newTabAllowedValues.includes(data.newTabGuid)) {
-    throw new Error(
+    throw new UserInputError(
       `Cannot create a scheduled entry with New Tab GUID of "${data.newTabGuid}".`
     );
   }

--- a/src/admin/server.ts
+++ b/src/admin/server.ts
@@ -5,7 +5,7 @@ import { typeDefsAdmin } from '../typeDefs';
 import { resolvers as resolversAdmin } from './resolvers';
 import responseCachePlugin from 'apollo-server-plugin-response-cache';
 import { GraphQLRequestContext } from 'apollo-server-types';
-import { sentryPlugin } from '@pocket-tools/apollo-utils';
+import { sentryPlugin, errorHandler } from '@pocket-tools/apollo-utils';
 import { ContextManager } from './context';
 import {
   ApolloServerPluginLandingPageDisabled,
@@ -28,6 +28,7 @@ export function getServer(contextFactory: ContextFactory): ApolloServer {
     schema: buildSubgraphSchema([
       { typeDefs: typeDefsAdmin, resolvers: resolversAdmin },
     ]),
+    formatError: errorHandler,
     plugins: [
       //Copied from Apollo docs, the sessionID signifies if we should separate out caches by user.
       responseCachePlugin({

--- a/src/database/mutations/ApprovedItem.ts
+++ b/src/database/mutations/ApprovedItem.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, ApprovedItem } from '@prisma/client';
 import { CreateApprovedItemInput, UpdateApprovedItemInput } from '../types';
+import { UserInputError } from 'apollo-server';
 
 /**
  * This mutation creates an approved curated item.
@@ -17,7 +18,7 @@ export async function createApprovedItem(
   });
 
   if (urlExists) {
-    throw new Error(
+    throw new UserInputError(
       `An approved item with the URL "${data.url}" already exists`
     );
   }
@@ -42,7 +43,7 @@ export async function updateApprovedItem(
   data: UpdateApprovedItemInput
 ): Promise<ApprovedItem> {
   if (!data.externalId) {
-    throw new Error('externalId must be provided.');
+    throw new UserInputError('externalId must be provided.');
   }
 
   // Check if the URL is unique.
@@ -51,7 +52,7 @@ export async function updateApprovedItem(
   });
 
   if (urlExists) {
-    throw new Error(
+    throw new UserInputError(
       `An approved item with the URL "${data.url}" already exists`
     );
   }

--- a/src/database/mutations/RejectedItem.ts
+++ b/src/database/mutations/RejectedItem.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, RejectedCuratedCorpusItem } from '@prisma/client';
 import { CreateRejectedItemInput } from '../types';
+import { UserInputError } from 'apollo-server';
 
 /**
  * This mutation creates a rejected item with the data provided.
@@ -17,7 +18,7 @@ export async function createRejectedItem(
   });
 
   if (urlExists) {
-    throw new Error(
+    throw new UserInputError(
       `A rejected item with the URL "${data.url}" already exists`
     );
   }

--- a/src/database/mutations/ScheduledItem.ts
+++ b/src/database/mutations/ScheduledItem.ts
@@ -4,6 +4,8 @@ import {
   DeleteScheduledItemInput,
   ScheduledItem,
 } from '../types';
+import { NotFoundError } from '@pocket-tools/apollo-utils';
+import { UserInputError } from 'apollo-server';
 
 /**
  * This mutation adds a scheduled entry for a New Tab.
@@ -22,7 +24,7 @@ export async function createScheduledItem(
   });
 
   if (!approvedItem) {
-    throw new Error(
+    throw new NotFoundError(
       `Cannot create a scheduled entry: Approved Item with id "${approvedItemExternalId}" does not exist.`
     );
   }
@@ -52,7 +54,7 @@ export async function deleteScheduledItem(
   data: DeleteScheduledItemInput
 ): Promise<ScheduledItem> {
   if (!data.externalId) {
-    throw new Error('externalId must be provided.');
+    throw new UserInputError('externalId must be provided.');
   }
 
   // Get the item to return with the mutation
@@ -71,7 +73,9 @@ export async function deleteScheduledItem(
       },
     });
   } else {
-    throw new Error(`Item with ID of '${data.externalId}' could not be found.`);
+    throw new NotFoundError(
+      `Item with ID of '${data.externalId}' could not be found.`
+    );
   }
 
   return scheduledItem;


### PR DESCRIPTION
## Goal

Implement better error handling patterns `t-infra` is adopting for their repositories and is keen for us to adopt, too.

- Updated mutations to throw custom Apollo Server errors such as UserInputError. Also making advantage of custom GraphQL errors from the @pocket-tools/apollo-utils package such as NotFoundError.
- Updated integration tests to assert for error codes in addition to messages.
Paired with @sri-kirsh on this earlier today.

Note that the code for `NotFoundError` is currently `INTERNAL_SERVER_ERROR`, which may not be the intended behaviour. I _think_ all that is needed is to update https://github.com/Pocket/apollo-utils/blob/5cba7af4e17a39f916de3c32fd1d5ec84434548f/src/errorHandler/errorHandler.ts#L27 to pass a custom code string (for example, `NOT_FOUND_ERROR`) and update the tests here once the package is updated. 

(Or maybe not as https://getpocket.atlassian.net/browse/INFRA-143 has more context for this. It looks like it's OK to leave things as they are in this PR.)

