### PR TITLE
[BACK-1219] Fix: error on not being able to delete an item doesn't appear

### DIFF
--- a/src/database/mutations/ApprovedItem.ts
+++ b/src/database/mutations/ApprovedItem.ts
@@ -1,6 +1,6 @@
 import { PrismaClient, ApprovedItem } from '@prisma/client';
 import { CreateApprovedItemInput, UpdateApprovedItemInput } from '../types';
-import { UserInputError } from 'apollo-server-express';
+import { ApolloError, UserInputError } from 'apollo-server';
 
 /**
  * This mutation creates an approved curated item.
@@ -53,7 +53,7 @@ export async function updateApprovedItem(
 
   if (urlExists) {
     throw new UserInputError(
-      `An approved item with the URL "${data.url}" already exists`
+      `An approved item with the URL "${data.url}" already exists.`
     );
   }
 
@@ -95,7 +95,7 @@ export async function deleteApprovedItem(
     where: { approvedItemId: approvedItem.id },
   });
   if (scheduledItems.length > 0) {
-    throw new Error(
+    throw new ApolloError(
       `Cannot remove item from approved corpus - scheduled entries exist.`
     );
   }


### PR DESCRIPTION
## Goal

It appears that once we switched to the error handler from the `apollo-utils` package throwing any old JavaScript error from the resolvers is not enough, it has to be one of the Apollo Server errors or it won't make its way all the way to the GraphQL server.

Now throwing an ApolloError where a JS Error was thrown before. This is the only error affected by this change - everywhere else the code is already throwing Apollo Server errors or descendants thereof from the `apollo-utils` package.

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1219

Frontend now receives the error:

<img width="1355" alt="frontend-receives-error" src="https://user-images.githubusercontent.com/22447785/145005943-094bcd26-8eb3-4064-9acb-0a9ab6be7ebe.png">

