### PR TITLE
feat(curated items): [BACK-1232] Add a check for URL already in corpus

### DIFF
--- a/src/admin/resolvers/mutations/RejectedItem.integration.ts
+++ b/src/admin/resolvers/mutations/RejectedItem.integration.ts
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { db, getServer } from '../../../test/admin-server';
 import {
   clearDb,
+  createApprovedItemHelper,
   createRejectedCuratedCorpusItemHelper,
 } from '../../../test/helpers';
 import { CREATE_REJECTED_ITEM } from '../../../test/admin-server/mutations.gql';
@@ -71,12 +72,12 @@ describe('mutations: RejectedItem', () => {
       ).to.equal(result.data?.createRejectedCuratedCorpusItem.externalId);
     });
 
-    it('should fail to create an approved item with a duplicate URL', async () => {
+    it('should fail to create a rejected item with a duplicate URL', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
       eventEmitter.on(ReviewedCorpusItemEventType.REJECT_ITEM, eventTracker);
 
-      // Create a approved item with a set URL
+      // Create a rejected item with a set URL
       await createRejectedCuratedCorpusItemHelper(db, {
         title: 'I was here first!',
         url: 'https://test.com/docker',
@@ -91,10 +92,42 @@ describe('mutations: RejectedItem', () => {
       // ...without success. There is no data
       expect(result.errors).not.to.be.null;
 
-      // And there is the right error from the resolvers
+      // And there is the correct error from the resolvers
       if (result.errors) {
         expect(result.errors[0].message).to.contain(
-          `A rejected item with the URL "${input.url}" already exists`
+          `A rejected item with the URL "${input.url}" already exists.`
+        );
+        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
+      }
+
+      // Check that the REJECT_ITEM event was not fired
+      expect(eventTracker.callCount).to.equal(0);
+    });
+
+    it('should fail to create a rejected item if URL is in approved corpus', async () => {
+      // Set up event tracking
+      const eventTracker = sinon.fake();
+      eventEmitter.on(ReviewedCorpusItemEventType.REJECT_ITEM, eventTracker);
+
+      // Create an approved item with a set URL
+      await createApprovedItemHelper(db, {
+        title: 'I was here first!',
+        url: 'https://test.com/docker',
+      });
+
+      // Attempt to create another item with the same URL
+      const result = await server.executeOperation({
+        query: CREATE_REJECTED_ITEM,
+        variables: input,
+      });
+
+      // ...without success. There is no data
+      expect(result.errors).not.to.be.null;
+
+      // And there is the correct error from the resolvers
+      if (result.errors) {
+        expect(result.errors[0].message).to.contain(
+          `An approved item with the URL "${input.url}" already exists.`
         );
         expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
       }

--- a/src/database/helpers/checkCorpusUrl.ts
+++ b/src/database/helpers/checkCorpusUrl.ts
@@ -1,0 +1,37 @@
+import { UserInputError } from 'apollo-server';
+import { PrismaClient } from '@prisma/client';
+
+/**
+ * Checks if an item with the given URL already exists in the Curated Corpus database.
+ *
+ * @param db
+ * @param url
+ */
+export const checkCorpusUrl = async (
+  db: PrismaClient,
+  url: string
+): Promise<void> => {
+  // Check if the URL is unique in the Approved Corpus.
+  const approvedUrlExists = await db.approvedItem.count({
+    where: { url },
+  });
+
+  if (approvedUrlExists) {
+    throw new UserInputError(
+      `An approved item with the URL "${url}" already exists.`
+    );
+  }
+
+  // Do another check to make sure it hasn't already been added by another user
+  // to the Rejected Corpus - an edge case the frontend should never allow but
+  // that we should cater for nevertheless.
+  const rejectedUrlExists = await db.rejectedCuratedCorpusItem.count({
+    where: { url },
+  });
+
+  if (rejectedUrlExists) {
+    throw new UserInputError(
+      `A rejected item with the URL "${url}" already exists.`
+    );
+  }
+};

--- a/src/database/mutations/RejectedItem.ts
+++ b/src/database/mutations/RejectedItem.ts
@@ -1,6 +1,6 @@
 import { PrismaClient, RejectedCuratedCorpusItem } from '@prisma/client';
 import { CreateRejectedItemInput } from '../types';
-import { UserInputError } from 'apollo-server';
+import { checkCorpusUrl } from '../helpers/checkCorpusUrl';
 
 /**
  * This mutation creates a rejected item with the data provided.
@@ -12,16 +12,8 @@ export async function createRejectedItem(
   db: PrismaClient,
   data: CreateRejectedItemInput
 ): Promise<RejectedCuratedCorpusItem> {
-  // Check if the URL is unique.
-  const urlExists = await db.rejectedCuratedCorpusItem.count({
-    where: { url: data.url },
-  });
-
-  if (urlExists) {
-    throw new UserInputError(
-      `A rejected item with the URL "${data.url}" already exists`
-    );
-  }
+  // Check if an item with this URL has already been created in the Curated Corpus.
+  await checkCorpusUrl(db, data.url);
 
   return db.rejectedCuratedCorpusItem.create({
     data: {


### PR DESCRIPTION
## Goal

We need to make sure that across both the rejected and approved curated
items a single URL appears only once. So all the existing mutations
for curated items need to be updated with a cross-check of the other table.

This cross-check has been moved to its own helper function, and its
functionality is covered by the new or updated integration tests in this
commit.

## References

JIRA ticket:
[Curated Corpus API - add an already in corpus check on approve/reject mutation](https://getpocket.atlassian.net/browse/BACK-1232)
