### PR TITLE
refactor(getNewTabsForUser): expect token in header

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -661,9 +661,9 @@ type Query {
     ): ApprovedCuratedCorpusItem!
 
     """
-    Retrieves all NewTabs available to the given SSO user.
+    Retrieves all NewTabs available to the given SSO user. Requires an Authorization header.
     """
-    getNewTabsForUser(token: String!): [NewTab!]!
+    getNewTabsForUser: [NewTab!]!
 }
 
 type Mutation {

--- a/src/admin/context.spec.ts
+++ b/src/admin/context.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+
+import { getTokenFromAuthorizationHeader } from './context';
+
+describe('context', () => {
+  describe('getTokenFromAuthorizationHeader', () => {
+    it('should return the token from a properly formed header', () => {
+      const header = 'Bearer videogametoken';
+
+      expect(getTokenFromAuthorizationHeader(header)).to.equal(
+        'videogametoken'
+      );
+    });
+
+    it('should return undefined from a malformed header', () => {
+      // there shouldn't be more than one space!
+      let header = 'Hack allyourbase belongtous';
+
+      expect(getTokenFromAuthorizationHeader(header)).to.be.undefined;
+
+      header = 'oopsnospaces!';
+
+      expect(getTokenFromAuthorizationHeader(header)).to.be.undefined;
+    });
+  });
+});

--- a/src/admin/resolvers/queries/NewTab.integration.ts
+++ b/src/admin/resolvers/queries/NewTab.integration.ts
@@ -16,13 +16,8 @@ describe('queries: NewTab', () => {
 
   describe('getNewTabsForUser query', () => {
     it('should get all newtabs until we enable SSO', async () => {
-      // the token below is the example from https://jwt.io/
       const { data } = await server.executeOperation({
         query: GET_NEW_TABS_FOR_USER,
-        variables: {
-          token:
-            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
-        },
       });
 
       const newTabs = data?.getNewTabsForUser;

--- a/src/admin/resolvers/queries/NewTab.ts
+++ b/src/admin/resolvers/queries/NewTab.ts
@@ -7,8 +7,9 @@ import { NewTab, NewTabs } from '../../../shared/types';
  * @param args
  * @param db
  */
-export function getNewTabsForUser(parent, args, _): NewTab[] {
-  // const token = { args };
+export function getNewTabsForUser(parent, args, { token }): NewTab[] {
+  // token comes from the context - see admin/context.ts
+  // console.log(token);
 
   // TODO: when implementing SSO, decrypt token, validate signature and check
   // groups, which will contain new tab guid values.

--- a/src/test/admin-server/queries.gql.ts
+++ b/src/test/admin-server/queries.gql.ts
@@ -86,8 +86,8 @@ export const GET_APPROVED_ITEM_BY_URL = gql`
 `;
 
 export const GET_NEW_TABS_FOR_USER = gql`
-  query getNewTabsForUser($token: String!) {
-    getNewTabsForUser(token: $token) {
+  query getNewTabsForUser {
+    getNewTabsForUser {
       guid
       name
       utcOffset


### PR DESCRIPTION
## Goal

follow pattern in client API and expect the user's token in the `Authorization` header instead of as a query param.

- added token logic to the admin server context
- updated graphql schema & resolver to no longer require a `token` param

## I'd love feedback/perspectives on:
- should decoding, validating, and parsing of the token be offloaded to the resolver? (we can make this decision later when SSO is actually implemented.)