### PR TITLE
fix(data integrity): [BACK-1246] Editing live corpus fails

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -498,10 +498,6 @@ input UpdateApprovedCuratedCorpusItemInput {
     """
     prospectId: ID!
     """
-    The URL of the Approved Item.
-    """
-    url: Url!
-    """
     The title of the Approved Item.
     """
     title: String!

--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -264,7 +264,6 @@ describe('mutations: ApprovedItem', () => {
         externalId: item.externalId,
         prospectId: '123-abc',
         title: 'Anything but LEGO',
-        url: 'https://test.com/lego',
         excerpt: 'Updated excerpt',
         status: CuratedStatus.CORPUS,
         imageUrl: 'https://test.com/image.png',
@@ -300,108 +299,6 @@ describe('mutations: ApprovedItem', () => {
       expect(
         await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
       ).to.equal(data?.updateApprovedCuratedCorpusItem.externalId);
-    });
-
-    it('should fail to update an approved item with a duplicate URL', async () => {
-      // Set up event tracking
-      const eventTracker = sinon.fake();
-      eventEmitter.on(ReviewedCorpusItemEventType.UPDATE_ITEM, eventTracker);
-
-      await createApprovedItemHelper(db, {
-        title: 'I was here first',
-        url: 'https://test.com/first',
-      });
-      const item = await createApprovedItemHelper(db, {
-        title: "3 Things Everyone Knows About LEGO That You Don't",
-        url: 'https://sample.com/three-things',
-      });
-
-      const input: UpdateApprovedItemInput = {
-        externalId: item.externalId,
-        prospectId: '456-qwe',
-        title: 'Anything but LEGO',
-        url: 'https://test.com/first',
-        excerpt: 'Updated excerpt',
-        status: CuratedStatus.RECOMMENDATION,
-        imageUrl: 'https://test.com/image.png',
-        language: 'de',
-        publisher: 'Brick Cloud',
-        topic: 'Business',
-        isCollection: true,
-        isShortLived: true,
-        isSyndicated: false,
-      };
-
-      // Attempt to update the second item with a duplicate URL...
-      const result = await server.executeOperation({
-        query: UPDATE_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      // ...without success. There is no data
-      expect(result.data).to.be.null;
-
-      // And there is the correct error from the resolvers
-      if (result.errors) {
-        expect(result.errors[0].message).to.contain(
-          `An approved item with the URL "${input.url}" already exists`
-        );
-        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
-      }
-
-      // Check that the UPDATE_ITEM event was not fired
-      expect(eventTracker.callCount).to.equal(0);
-    });
-
-    it('should fail to update an approved item if a rejected item with the same URL exists', async () => {
-      // Set up event tracking
-      const eventTracker = sinon.fake();
-      eventEmitter.on(ReviewedCorpusItemEventType.UPDATE_ITEM, eventTracker);
-
-      await createRejectedCuratedCorpusItemHelper(db, {
-        title: 'I was here first',
-        url: 'https://test.com/first',
-      });
-      const item = await createApprovedItemHelper(db, {
-        title: "3 Things Everyone Knows About LEGO That You Don't",
-        url: 'https://sample.com/three-things',
-      });
-
-      const input: UpdateApprovedItemInput = {
-        externalId: item.externalId,
-        prospectId: '456-qwe',
-        title: 'Anything but LEGO',
-        url: 'https://test.com/first',
-        excerpt: 'Updated excerpt',
-        status: CuratedStatus.RECOMMENDATION,
-        imageUrl: 'https://test.com/image.png',
-        language: 'de',
-        publisher: 'Brick Cloud',
-        topic: 'Business',
-        isCollection: true,
-        isShortLived: true,
-        isSyndicated: false,
-      };
-
-      // Attempt to update the second item with a duplicate URL...
-      const result = await server.executeOperation({
-        query: UPDATE_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      // ...without success. There is no data
-      expect(result.data).to.be.null;
-
-      // And there is the correct error from the resolvers
-      if (result.errors) {
-        expect(result.errors[0].message).to.contain(
-          `A rejected item with the URL "${input.url}" already exists`
-        );
-        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
-      }
-
-      // Check that the UPDATE_ITEM event was not fired
-      expect(eventTracker.callCount).to.equal(0);
     });
   });
 

--- a/src/database/helpers/checkCorpusUrl.ts
+++ b/src/database/helpers/checkCorpusUrl.ts
@@ -6,24 +6,14 @@ import { PrismaClient } from '@prisma/client';
  *
  * @param db
  * @param url
- * @param externalId
  */
 export const checkCorpusUrl = async (
   db: PrismaClient,
-  url: string,
-  externalId?: string
+  url: string
 ): Promise<void> => {
-  // Build the WHERE clause. Look up if there are any records with the given URL.
-  const whereClause: any = { url };
-
-  // If an external ID of the item was provided, exclude it from the lookup.
-  if (externalId) {
-    whereClause.externalId = { not: externalId };
-  }
-
   // Check if the URL is unique in the Approved Corpus.
   const approvedUrlExists = await db.approvedItem.count({
-    where: whereClause,
+    where: { url },
   });
 
   if (approvedUrlExists) {
@@ -36,7 +26,7 @@ export const checkCorpusUrl = async (
   // to the Rejected Corpus - an edge case the frontend should never allow but
   // that we should cater for nevertheless.
   const rejectedUrlExists = await db.rejectedCuratedCorpusItem.count({
-    where: whereClause,
+    where: { url },
   });
 
   if (rejectedUrlExists) {

--- a/src/database/mutations/ApprovedItem.ts
+++ b/src/database/mutations/ApprovedItem.ts
@@ -38,11 +38,6 @@ export async function updateApprovedItem(
   if (!data.externalId) {
     throw new UserInputError('externalId must be provided.');
   }
-
-  // If the URL has been updated, we need to check if there's a pre-existing
-  // corpus item with the same URL and disallow the update if needed.
-  await checkCorpusUrl(db, data.url, data.externalId);
-
   return db.approvedItem.update({
     where: { externalId: data.externalId },
     data: {

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -32,7 +32,6 @@ export type RejectedCuratedCorpusItemFilter = {
  */
 type ApprovedItemRequiredInput = {
   prospectId: string;
-  url: string;
   title: string;
   excerpt: string;
   status: CuratedStatus;
@@ -46,6 +45,7 @@ type ApprovedItemRequiredInput = {
 };
 
 export type CreateApprovedItemInput = ApprovedItemRequiredInput & {
+  url: string;
   scheduledDate?: string;
   newTabGuid?: string;
 };


### PR DESCRIPTION
## Goal
We need to fix a side effect of implementing a data integrity check in #320 - existing curated items should still be editable instead of returning an error. 

Fixed an overzealous check for URL uniqueness across the approved and rejected corpora. ~Now passing the external ID to be excluded from the check in the `updateApprovedCuratedCorpusItem` mutation.~

Update following review feedback:

- Removed the URL field from the `updateApprovedCuratedCorpusItem` mutation as the URL should never be changed once the item is created.

- Removed a check for URL uniqueness from the update mutation.

- Reverted the `checkCorpusUrl` check to what it was previously - no extra params to accommodate the update mutation.

- Removed obsolete integration tests.

## I'd love feedback/perspectives on:
It is a little worrying that the existing integration tests did not catch this. Please help me write a test that _will_ catch this. Alternatively, you could tell me not to worry about it :). Integration tests for the `updateApprovedCuratedCorpusItem` mutations [live here](https://github.com/Pocket/curated-corpus-api/blob/67176605f69c512fceb7572a600edc0f07727908/src/admin/resolvers/mutations/ApprovedItem.integration.ts#L251).

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1246