### PR TITLE
feat(approved item): Remove `isSyndicated`, `isCollection` from update mutation input (BACK-1257)

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -527,18 +527,10 @@ input UpdateApprovedCuratedCorpusItemInput {
     """
     topic: String!
     """
-    Whether this story is a Pocket Collection.
-    """
-    isCollection: Boolean!
-    """
     A flag to ML to not recommend this item long term after it is added to the corpus.
     Example: a story covering an election.
     """
     isShortLived: Boolean!
-    """
-    Whether this item is a syndicated article.
-    """
-    isSyndicated: Boolean!
 }
 
 """

--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -270,9 +270,7 @@ describe('mutations: ApprovedItem', () => {
         language: 'de',
         publisher: 'Cloud Factory',
         topic: 'Business',
-        isCollection: true,
         isShortLived: true,
-        isSyndicated: false,
       };
 
       const { data } = await server.executeOperation({

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -39,13 +39,17 @@ type ApprovedItemRequiredInput = {
   publisher: string;
   imageUrl: string;
   topic: string;
-  isCollection: boolean;
   isShortLived: boolean;
-  isSyndicated: boolean;
 };
 
 export type CreateApprovedItemInput = ApprovedItemRequiredInput & {
+  // These required properties are set once only at creation time
+  // and never changed, so they're not part of the shared input type above.
   url: string;
+  isCollection: boolean;
+  isSyndicated: boolean;
+  // These are optional properties for approving AND scheduling the item
+  // on New Tab at the same time.
   scheduledDate?: string;
   newTabGuid?: string;
 };


### PR DESCRIPTION
## Goal

Just like with the URL that is set once on creation and never changed again, isCollection and isSyndicated properties are set when a prospect is approved and never changed again.

So there is no reason for these to be part of the input variables for the `updateApprovedCuratedCorpusItem` mutation. Ticket has link to Slack for more context.


## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1257