### PR TITLE
fix(scheduling): Prevent duplicate scheduling [BACK-1245]

### DIFF
--- a/prisma/migrations/20220107025919_prevent_duplicate_scheduling/migration.sql
+++ b/prisma/migrations/20220107025919_prevent_duplicate_scheduling/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[approvedItemId,newTabGuid,scheduledDate]` on the table `ScheduledItem` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX `ScheduledItem_approvedItemId_newTabGuid_scheduledDate_key` ON `ScheduledItem`(`approvedItemId`, `newTabGuid`, `scheduledDate`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,4 +85,6 @@ model ScheduledItem {
 
   // indexes
   @@unique([externalId])
+  // Prevent scheduling the same item on the same new tab for the same day multiple times.
+  @@unique([approvedItemId, newTabGuid, scheduledDate], name: "ItemNewTabDate")
 }

--- a/src/database/mutations/ScheduledItem.ts
+++ b/src/database/mutations/ScheduledItem.ts
@@ -5,7 +5,6 @@ import {
   ScheduledItem,
 } from '../types';
 import { NotFoundError } from '@pocket-tools/apollo-utils';
-import { UserInputError } from 'apollo-server';
 
 /**
  * This mutation adds a scheduled entry for a New Tab.
@@ -53,10 +52,6 @@ export async function deleteScheduledItem(
   db: PrismaClient,
   data: DeleteScheduledItemInput
 ): Promise<ScheduledItem> {
-  if (!data.externalId) {
-    throw new UserInputError('externalId must be provided.');
-  }
-
   // Get the item to return with the mutation
   const scheduledItem = await db.scheduledItem.findUnique({
     where: { externalId: data.externalId },


### PR DESCRIPTION
## Goal

Fix for the scenario where users may accidentally schedule the same story
for the same new tab/date combination without realising their mistake.

- Added a unique index constraint in the database on the combination of
scheduled date, new tab guid and curated item external id values.

- Now intercepting the error thrown by Prisma when this unique constraint is
violated in the mutation resolver and returning a user-friendly message instead.

- Added an integration test to cover this edge case.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1245

## Video walkthrough

It's easiest to show this change and how it appears on the frontend with a short video walkthrough.
_Note_: no frontend updates required.


https://user-images.githubusercontent.com/22447785/148497769-e1f0c8ae-4c8f-458f-93ed-c207600a8066.mov



