### PR TITLE
chore(tests): Add unit tests check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,9 +187,10 @@ jobs:
 workflows:
   all:
     jobs:
-      #- pocket/node_mocha_ts_test:
-      #    <<: *not_main
-      #    name: test
+      - pocket/node_mocha_ts_test:
+          <<: *not_main
+          name: test
+
       - test_integrations:
           <<: *not_main
           name: test_integrations


### PR DESCRIPTION
## Goal

Initially, the only tests we had in this repository were integration tests for which a docker-backed job was set up. Since then, `.spec.ts` tests have been added but there's nothing that's running those tests for each PR. This update fixes that.

Here is the new check for this PR: https://app.circleci.com/pipelines/github/Pocket/curated-corpus-api/1671/workflows/ec97ceff-0ece-46f6-9655-2e969deba5a0/jobs/6742
