### PR TITLE
refactor(getApprovedCuratedCorpusItemByUrl): [BACK-1264] return null when no url is found

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -646,7 +646,7 @@ type Query {
         The URL of the approved item.
         """
         url: String!
-    ): ApprovedCuratedCorpusItem!
+    ): ApprovedCuratedCorpusItem
 
     """
     Retrieves all NewTabs available to the given SSO user. Requires an Authorization header.

--- a/src/admin/resolvers/queries/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.integration.ts
@@ -354,8 +354,8 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
       expect(item.isSyndicated).to.be.a('boolean');
     });
 
-    it('should return a user-friendly error if no item is found', async () => {
-      const inputUrl = 'https://www.test.com/story-five';
+    it('should return null when no url is found', async () => {
+      const inputUrl = 'https://www.test-no-url-found.com/story-five';
 
       const result = await server.executeOperation({
         query: GET_APPROVED_ITEM_BY_URL,
@@ -364,19 +364,13 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
         },
       });
 
+      expect(result.data).to.have.property('getApprovedCuratedCorpusItemByUrl');
+
       // There should be no data returned
-      expect(result.data).to.be.null;
+      expect(result.data?.getApprovedCuratedCorpusItemByUrl).to.be.null;
 
-      // There should be errors
-      expect(result.errors).not.to.be.null;
-
-      // And the error thrown should be the one set in the resolver
-      if (result.errors) {
-        expect(result.errors[0].message).to.contain(
-          `Could not find a curated item with the following URL: "${inputUrl}".`
-        );
-        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
-      }
+      // There should be no errors
+      expect(result.errors).to.be.undefined;
     });
   });
 });

--- a/src/admin/resolvers/queries/ApprovedItem.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.ts
@@ -43,8 +43,8 @@ export async function getApprovedItems(
 
 /**
  * This query returns an approved item with a given URL if it finds one
- * in the Curated Corpus (among approved items only), or throws
- * a User Input error otherwise.
+ * in the Curated Corpus (among approved items only), or
+ * return null if the url is not found
  *
  * @param parent
  * @param args
@@ -54,6 +54,6 @@ export async function getApprovedItemByUrl(
   parent,
   args,
   { db }
-): Promise<ApprovedItem> {
+): Promise<ApprovedItem | null> {
   return await dbGetApprovedItemByUrl(db, args.url);
 }

--- a/src/database/queries/ApprovedItem.ts
+++ b/src/database/queries/ApprovedItem.ts
@@ -6,7 +6,6 @@ import {
   Connection,
 } from '@devoxa/prisma-relay-cursor-connection';
 import { ApprovedItemFilter, PaginationInput } from '../types';
-import { UserInputError } from 'apollo-server';
 
 /**
  * A dedicated type for the unique cursor value used in the getCuratedItems query.
@@ -73,7 +72,8 @@ export async function getApprovedItems(
 }
 
 /**
- * Return an approved item with the given URL if found in the Curated Corpus.
+ * Return an approved item with the given URL if found in the Curated Corpus or
+ * return null if the url is not found
  *
  * @param db
  * @param url
@@ -81,16 +81,8 @@ export async function getApprovedItems(
 export async function getApprovedItemByUrl(
   db: PrismaClient,
   url: string
-): Promise<ApprovedItem> {
-  const approvedItem = await db.approvedItem.findUnique({ where: { url } });
-
-  if (!approvedItem) {
-    throw new UserInputError(
-      `Could not find a curated item with the following URL: "${url}".`
-    );
-  }
-
-  return approvedItem;
+): Promise<ApprovedItem | null> {
+  return db.approvedItem.findUnique({ where: { url } });
 }
 
 /**


### PR DESCRIPTION
## Goal
Return `null` when a url doesn't exist in the database

JIRA ticket:
* [BACK-1264]

[BACK-1264]: https://getpocket.atlassian.net/browse/BACK-1264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ