### PR TITLE
fix(snowplow): Allow Dependabot to access secret vars for Snowplow GitHub action

### DIFF
--- a/.github/workflows/verify-snowplow.yml
+++ b/.github/workflows/verify-snowplow.yml
@@ -1,10 +1,13 @@
+#####################################
+# For documentation, see https://docs.snowplowanalytics.com/docs/managing-data-quality/testing-and-qa-workflows/using-the-data-structures-ci-tool-for-data-quality/
+####################################
 name: Verify Snowplow Schema Dependencies
 
 ####################################
 # Start the job on all PRs to main #
 ####################################
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
 
@@ -27,4 +30,7 @@ jobs:
           organization-id: ${{ secrets.SNOWPLOW_ORG_ID }}
           api-key: ${{ secrets.SNOWPLOW_API_KEY }}
           manifest-path: '.github/workflows/snowplow/schemas.json'
+          # Note options here are DEV or PROD. These are magic Snowplow words
+          # and they don't correspond to traditional Node env values such as
+          # 'production'
           environment: PROD


### PR DESCRIPTION
## Goal

All the Dependabot PRs are failing the Snowplow schemas check as they don't have access to the secret vars. The aim of this PR is to undo all wrongs here and let Dependabot PRs get autoapproved in peace.

- Updated the check
- Added link to Snowplow docs for their GitHub action, and a note on the `PROD` environment value.