### PR TITLE
refactor(prospectId): make prospectId optional

### DIFF
--- a/prisma/migrations/20220125153828_make_prospect_id_optional_for_approved_and_rejected/migration.sql
+++ b/prisma/migrations/20220125153828_make_prospect_id_optional_for_approved_and_rejected/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE `ApprovedItem` MODIFY `prospectId` VARCHAR(255) NULL;
+
+-- AlterTable
+ALTER TABLE `RejectedCuratedCorpusItem` MODIFY `prospectId` VARCHAR(255) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,7 @@ model ApprovedItem {
   // fields
   id              Int           @id @default(autoincrement())
   externalId      String        @default(uuid()) @db.VarChar(255)
-  prospectId      String        @db.VarChar(255)
+  prospectId      String?       @db.VarChar(255)
   url             String        @db.VarChar(500)
   title           String        @db.VarChar(255)
   excerpt         String        @db.Text
@@ -49,7 +49,7 @@ model RejectedCuratedCorpusItem {
   // fields
   id         Int      @id @default(autoincrement())
   externalId String   @default(uuid()) @db.VarChar(255)
-  prospectId String   @db.VarChar(255)
+  prospectId String?  @db.VarChar(255)
   url        String   @db.VarChar(500)
   title      String?  @db.VarChar(255)
   topic      String   @db.VarChar(255)

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -105,9 +105,9 @@ type ApprovedCuratedCorpusItem {
     """
     externalId: ID!
     """
-    The GUID of the corresponding Prospect ID.
+    The GUID of the corresponding Prospect ID. Will be empty if the item was manually added.
     """
-    prospectId: ID!
+    prospectId: ID
     """
     The URL of the story.
     """
@@ -182,9 +182,9 @@ type RejectedCuratedCorpusItem {
     """
     externalId: ID!
     """
-    The GUID of the corresponding Prospect ID.
+    The GUID of the corresponding Prospect ID. Will be empty if the item was manually added.
     """
-    prospectId: ID!
+    prospectId: ID
     """
     The URL of the story.
     """
@@ -426,9 +426,9 @@ Input data for creating an Approved Item and optionally scheduling this item to 
 """
 input CreateApprovedCuratedCorpusItemInput {
     """
-    The GUID of the corresponding Prospect ID.
+    The GUID of the corresponding Prospect ID. Will be empty for manually added items.
     """
-    prospectId: ID!
+    prospectId: ID
     """
     The URL of the Approved Item.
     """
@@ -494,10 +494,6 @@ input UpdateApprovedCuratedCorpusItemInput {
     """
     externalId: ID!
     """
-    The GUID of the corresponding Prospect ID.
-    """
-    prospectId: ID!
-    """
     The title of the Approved Item.
     """
     title: String!
@@ -552,9 +548,9 @@ Input data for creating a Rejected Item.
 """
 input CreateRejectedCuratedCorpusItemInput {
     """
-    The GUID of the corresponding Prospect ID.
+    The GUID of the corresponding Prospect ID. Will be empty for manually added item.
     """
-    prospectId: ID!
+    prospectId: ID
     """
     The URL of the Rejected Item.
     """

--- a/src/admin/resolvers/mutations/ApprovedItem.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.ts
@@ -111,7 +111,8 @@ export async function rejectApprovedItem(
   // From our thoughtfully saved before deletion Approved Item, construct
   // input data for a Rejected Item entry.
   const input: CreateRejectedItemInput = {
-    prospectId: approvedItem.prospectId,
+    // manually added items do not have a prospectId
+    prospectId: approvedItem.prospectId || undefined,
     url: approvedItem.url,
     title: approvedItem.title,
     topic: approvedItem.topic,

--- a/src/admin/resolvers/queries/NewTab.integration.ts
+++ b/src/admin/resolvers/queries/NewTab.integration.ts
@@ -23,7 +23,7 @@ describe('queries: NewTab', () => {
       const newTabs = data?.getNewTabsForUser;
 
       // we currently have two available new tabs
-      expect(newTabs.length).to.equal(2);
+      expect(newTabs.length).to.equal(4);
 
       newTabs.forEach((newTab) => {
         expect(newTab.guid).not.to.be.undefined;

--- a/src/admin/resolvers/queries/NewTab.ts
+++ b/src/admin/resolvers/queries/NewTab.ts
@@ -18,7 +18,7 @@ export function getNewTabsForUser(parent, args, { token }): NewTab[] {
   // the groups. we'll cross that bridge when we come to it.
 
   // until SSO is set up, just return all new tabs
-  const userGroups = ['EN_US', 'DE_DE'];
+  const userGroups = ['EN_US', 'DE_DE', 'EN_GB', 'EN_INTL'];
 
   return NewTabs.filter((newTab) => {
     return userGroups.includes(newTab.guid);

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -31,7 +31,7 @@ export type RejectedCuratedCorpusItemFilter = {
  * mutations.
  */
 type ApprovedItemRequiredInput = {
-  prospectId: string;
+  prospectId?: string;
   title: string;
   excerpt: string;
   status: CuratedStatus;
@@ -54,9 +54,12 @@ export type CreateApprovedItemInput = ApprovedItemRequiredInput & {
   newTabGuid?: string;
 };
 
-export type UpdateApprovedItemInput = {
+export type UpdateApprovedItemInput = Omit<
+  ApprovedItemRequiredInput,
+  'prospectId'
+> & {
   externalId: string;
-} & ApprovedItemRequiredInput;
+};
 
 export type RejectApprovedItemInput = {
   externalId: string;
@@ -64,7 +67,7 @@ export type RejectApprovedItemInput = {
 };
 
 export type CreateRejectedItemInput = {
-  prospectId: string;
+  prospectId?: string;
   url: string;
   title?: string;
   topic: string;

--- a/src/events/snowplow/ReviewedItemSnowplowHandler.ts
+++ b/src/events/snowplow/ReviewedItemSnowplowHandler.ts
@@ -103,7 +103,8 @@ export class ReviewedItemSnowplowHandler extends CuratedCorpusSnowplowHandler {
         object_version: ObjectVersion.NEW,
         url: item.url,
         corpus_review_status: corpusReviewStatus,
-        prospect_id: item.prospectId,
+        // manually added items do not have a prospectId
+        prospect_id: item.prospectId || undefined,
         topic: item.topic,
         created_at: getUnixTimestamp(item.createdAt),
         created_by: item.createdBy,


### PR DESCRIPTION
## Goal

update db and graphql schema to allow for optional/empty `prospectId`. manually added items will not have this value.

- update hard-coded new tabs returned

will require frontend changes as well.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1287