### PR TITLE
refactor(shared data): rename new tab to scheduled surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The Curated Corpus API serves three primary functions:
 
 1. Allow our editorial team to manage both an approved corpus and a rejected corpus.
-2. Allow our editorial team to schedule approved corpus items across a number of Firefox New Tabs.
+2. Allow our editorial team to schedule approved corpus items across a number of Scheduled Surfaces (e.g. Firefox New Tab).
 3. Allow the ML team access to approved corpus items for eventual display on Pocket surfaces.
 
 The corpus is managed by editors through our [curation admin tools](https://github.com/Pocket/curation-admin-tools). These tools allow editors to customize meta information about approved items - title, excerpt, image, etc. The approved corpus is the authoritative source for this meta information (_not_ the [Parser](https://github.com/Pocket/Parser)).
@@ -15,12 +15,12 @@ Items in the approved corpus are available to be recommended across Pocket surfa
 ## Application Overview
 
 This app is a GraphQL API written in TypeScript. To serve the API, the following packages are used:
+
 - [Express](https://expressjs.com/) and [Apollo Server](https://www.apollographql.com/docs/apollo-server/),
 - [Prisma](https://www.prisma.io/) as an ORM to a MySQL relational database,
 - [prisma-relay-cursor-connection](https://github.com/devoxa/prisma-relay-cursor-connection) for Relay-style pagination,
 - S3 for image storage,
 - [Jest](https://jestjs.io/) and [Chai](https://www.chaijs.com/) for integration and unit testing.
-
 
 ### GraphQL Schemas
 
@@ -36,7 +36,7 @@ Having two schemas means we need two GraphQL endpoints, meaning two Apollo Serve
 
 ### Pagination
 
-This API implements [Relay-style pagination](https://relay.dev/graphql/connections.htm) with the assistance of the [prisma-relay-cursor-connection](https://github.com/devoxa/prisma-relay-cursor-connection) package. 
+This API implements [Relay-style pagination](https://relay.dev/graphql/connections.htm) with the assistance of the [prisma-relay-cursor-connection](https://github.com/devoxa/prisma-relay-cursor-connection) package.
 
 It is important that the `PageInfo` type and the `PaginationInput` in the shared GraphQL schema do not deviate from implementations in our other federated APIs. In other words, please leave them exactly as they were initially implemented (this includes accompanying comments) to avoid schema composition errors.
 
@@ -62,20 +62,24 @@ cd curated-corpus-api
 ```
 
 Generate the Prisma types (they will live in your `node_modules` folder):
+
 ```bash
 npx prisma generate
 ```
 
 Start Docker:
+
 ```bash
 docker compose up
 ```
 
 Once all the Docker containers are up and running, you should be able to reach
+
 - the public API at `http://localhost:4025/`
 - the admin API at `http://localhost:4025/admin`
 
 Out of the box, the local installation doesn't have any actual data for you to fetch or manipulate through the API. To seed some sample data for your local dev environment, run
+
 ```bash
 docker compose exec app npx prisma migrate reset
 ```
@@ -87,24 +91,29 @@ Note that the above command will not be adding to any data you may have added to
 So far we only have integration tests in this repository, and these wipe the database on each run, which means it's ~really tricky~ impossible as yet to have them running in the background in watch mode while you code.
 
 To run integration tests inside Docker, execute the following command:
+
 ```bash
 docker compose exec app npm run test-integrations
 ```
 
 To run these tests in watch mode, use
+
 ```bash
 docker compose exec app npm run test-integration:watch
 ```
 
 If you'd like to be able to run and debug integration tests directly in your IDE, run the following command (note that it may prompt you for your `sudo` password to modify your `/etc/hosts` file):
+
 ```bash
 npm run test-setup
 ```
 
-Thereafter, you can use 
+Thereafter, you can use
+
 ```bash
 npm run test-integrations
 ```
+
 on the command line or use your IDE to debug individual tests and test suites.
 
 ## Making changes to the Prisma schema
@@ -116,7 +125,6 @@ docker compose exec app npx prisma migrate dev --name some_meaningful_migration_
 ```
 
 This will create a migration script in `prisma/migrations` and will automatically run the new migration. This will also re-create your Prisma Typescript types.
-
 
 ## Testing on Dev
 
@@ -143,9 +151,11 @@ At the initial deployment, and also from time to time as the API evolves, it is 
 - Make sure you've run `npm ci` locally (outside of Docker).
 - Log in to AWS to find the Dev database connection URL. Look in the Secrets Manager - there will be the full DB URL stored there alongside individual DB connection parameters such as username and password.
 - Put that connection in your local environment file (`PATH_TO_REPOSITORY/.env`) as
+
 ```dotenv
 DATABASE_URL=[DB_URL_FROM_SECRETS_MANAGER]
 ```
+
 - Authenticate to Dev AWS in your terminal using `$(maws)`.
 - Connect to Pocket VPN Dev.
 - Run `npx prisma migrate reset` in your local terminal. This should use the Dev database connection URL as the target.

--- a/prisma/migrations/20220210161240_rename_newtab_to_scheduledsurface/migration.sql
+++ b/prisma/migrations/20220210161240_rename_newtab_to_scheduledsurface/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `newTabGuid` on the `ScheduledItem` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[approvedItemId,scheduledSurfaceGuid,scheduledDate]` on the table `ScheduledItem` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `scheduledSurfaceGuid` to the `ScheduledItem` table without a default value. This is not possible if the table is not empty.
+
+*/
+
+-- CUSTOM! we have to drop the foreign key first or mysql won't let us drop the index below
+ALTER TABLE `ScheduledItem` DROP FOREIGN KEY `ScheduledItem_approvedItemId_fkey`;
+
+-- DropIndex
+DROP INDEX `ScheduledItem_approvedItemId_newTabGuid_scheduledDate_key` ON `ScheduledItem`;
+
+-- AlterTable
+ALTER TABLE `ScheduledItem` DROP COLUMN `newTabGuid`,
+    ADD COLUMN `scheduledSurfaceGuid` VARCHAR(50) NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `ScheduledItem_approvedItemId_scheduledSurfaceGuid_scheduledD_key` ON `ScheduledItem`(`approvedItemId`, `scheduledSurfaceGuid`, `scheduledDate`);
+
+-- CUSTOM! recreate the foreign key we had to drop above
+ALTER TABLE `ScheduledItem` ADD CONSTRAINT `ScheduledItem_approvedItemId_fkey` FOREIGN KEY (`approvedItemId`) REFERENCES `ApprovedItem` (`id`) ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ enum CuratedStatus {
 }
 
 // A prospect that is deemed good enough for saving in the corpus
-// and (optionally) making it to New Tab.
+// and (optionally) making it to a Scheduled Surface.
 model ApprovedItem {
   // fields
   id              Int           @id @default(autoincrement())
@@ -67,24 +67,24 @@ model RejectedCuratedCorpusItem {
   @@unique([url])
 }
 
-// A curated item that's been scheduled to go on to one or more New Tabs
+// A curated item that's been scheduled to go on to one or more Scheduled Surfaces
 model ScheduledItem {
   // fields
-  id             Int      @id @default(autoincrement())
-  externalId     String   @default(uuid()) @db.VarChar(255)
-  approvedItemId Int
-  newTabGuid     String   @db.VarChar(10)
-  createdAt      DateTime @default(now())
-  createdBy      String   @db.VarChar(255)
-  updatedAt      DateTime @updatedAt
-  updatedBy      String?  @db.VarChar(255)
-  scheduledDate  DateTime @db.Date
+  id                       Int      @id @default(autoincrement())
+  externalId               String   @default(uuid()) @db.VarChar(255)
+  approvedItemId           Int
+  scheduledSurfaceGuid     String   @db.VarChar(50)
+  createdAt                DateTime @default(now())
+  createdBy                String   @db.VarChar(255)
+  updatedAt                DateTime @updatedAt
+  updatedBy                String?  @db.VarChar(255)
+  scheduledDate            DateTime @db.Date
 
   // associated entities
   approvedItem ApprovedItem @relation(fields: [approvedItemId], references: [id])
 
   // indexes
   @@unique([externalId])
-  // Prevent scheduling the same item on the same new tab for the same day multiple times.
-  @@unique([approvedItemId, newTabGuid, scheduledDate], name: "ItemNewTabDate")
+  // Prevent scheduling the same item on the same Scheduled Surface for the same day multiple times.
+  @@unique([approvedItemId, scheduledSurfaceGuid, scheduledDate], name: "ItemScheduledSurfaceDate")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -23,7 +23,10 @@ async function main() {
     const approvedItem = await createApprovedItemHelper(prisma, { title });
 
     await createScheduledItemHelper(prisma, {
-      newTabGuid: faker.random.arrayElement(['EN_US', 'DE_DE']),
+      scheduledSurfaceGuid: faker.random.arrayElement([
+        'NEW_TAB_EN_US',
+        'NEW_TAB_DE_DE',
+      ]),
       approvedItem,
     }).catch(console.error);
   }

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -72,22 +72,23 @@ enum ProspectType {
     GLOBAL
     ORGANIC_TIMESPENT
     SYNDICATED
+    TOP_SAVED
 }
 
 """
-A New Tab, including its associated Prospect Types.
+A Scheduled Surface, including its associated Prospect Types.
 """
-type NewTab {
+type ScheduledSurface {
     """
-    The GUID of the New Tab. Example: 'EN_US'.
+    The GUID of the Scheduled Surface. Example: 'NEW_TAB_EN_US'.
     """
     guid: String!
     """
-    The display name of the New Tab. Example 'en-US'.
+    The display name of the Scheduled Surface. Example 'New Tab (en-US)'.
     """
     name: String!
     """
-    The UTC offset of the New Tab's scheduling day, represented in HMM numeric format.
+    The UTC offset of the Scheduled Surface's scheduling day, represented in HMM numeric format.
     """
     utcOffset: Int!
     """
@@ -292,7 +293,7 @@ type RejectedCuratedCorpusItemConnection {
 }
 
 """
-A scheduled entry for an Approved Item to appear on a New Tab Feed.
+A scheduled entry for an Approved Item to appear on a Scheduled Surface.
 For example, a story that is scheduled to appear on December 31st, 2021 on the New Tab in Firefox for the US audience.
 """
 type ScheduledCuratedCorpusItem {
@@ -317,8 +318,8 @@ type ScheduledCuratedCorpusItem {
     """
     updatedBy: String
     """
-    The date the associated Approved Item is scheduled to appear on New Tab.
-    This date is relative to the time zone of the New Tab. Format: YYYY-MM-DD.
+    The date the associated Approved Item is scheduled to appear on a Scheduled Surface.
+    This date is relative to the time zone of the Scheduled Surface. Format: YYYY-MM-DD.
     """
     scheduledDate: Date!
     """
@@ -348,7 +349,7 @@ type ScheduledCuratedCorpusItemsResult {
     """
     totalCount: Int!
     """
-    An array of items for a given New Tab Feed
+    An array of items for a given Scheduled Surface
     """
     items: [ScheduledCuratedCorpusItem!]!
 }
@@ -404,13 +405,13 @@ input RejectedCuratedCorpusItemFilter {
 }
 
 """
-Available fields for filtering scheduled items for a given New Tab.
+Available fields for filtering scheduled items for a given Scheduled Surface.
 """
 input ScheduledCuratedCorpusItemsFilterInput {
     """
-    The GUID of the New Tab. Example: 'EN_US'.
+    The GUID of the Scheduled Surface. Example: 'NEW_TAB_EN_US'.
     """
-    newTabGuid: ID!
+    scheduledSurfaceGuid: ID!
     """
     Which day to show scheduled items from. Expects a date in YYYY-MM-DD format.
     """
@@ -422,7 +423,7 @@ input ScheduledCuratedCorpusItemsFilterInput {
 }
 
 """
-Input data for creating an Approved Item and optionally scheduling this item to appear on New Tab.
+Input data for creating an Approved Item and optionally scheduling this item to appear on a Scheduled Surface.
 """
 input CreateApprovedCuratedCorpusItemInput {
     """
@@ -476,13 +477,13 @@ input CreateApprovedCuratedCorpusItemInput {
     """
     isSyndicated: Boolean!
     """
-    Optionally, specify the date this item should be appearing on New Tab. Format: YYYY-MM-DD
+    Optionally, specify the date this item should be appearing on a Scheduled Surface. Format: YYYY-MM-DD
     """
     scheduledDate: Date
     """
-    Optionally, specify the GUID of the New Tab this item should be scheduled for.
+    Optionally, specify the GUID of the Scheduled Surface this item should be scheduled for.
     """
-    newTabGuid: ID
+    scheduledSurfaceGuid: ID
 }
 
 """
@@ -579,7 +580,7 @@ input CreateRejectedCuratedCorpusItemInput {
 }
 
 """
-Input data for creating a scheduled entry for an Approved Item on a New Tab Feed.
+Input data for creating a scheduled entry for an Approved Item on a Scheduled Surface.
 """
 input CreateScheduledCuratedCorpusItemInput {
     """
@@ -587,17 +588,17 @@ input CreateScheduledCuratedCorpusItemInput {
     """
     approvedItemExternalId: ID!
     """
-    The GUID of the New Tab Feed the Approved Item is going to appear on. Example: 'EN_US'.
+    The GUID of the Scheduled Surface the Approved Item is going to appear on. Example: 'NEW_TAB_EN_US'.
     """
-    newTabGuid: ID!
+    scheduledSurfaceGuid: ID!
     """
-    The date the associated Approved Item is scheduled to appear on New Tab. Format: YYYY-MM-DD.
+    The date the associated Approved Item is scheduled to appear on a Scheduled Surface. Format: YYYY-MM-DD.
     """
     scheduledDate: Date!
 }
 
 """
-Input data for deleting a scheduled item for a New Tab Feed.
+Input data for deleting a scheduled item for a Scheduled Surface.
 """
 input DeleteScheduledCuratedCorpusItemInput {
     """
@@ -624,11 +625,11 @@ type Query {
     ): RejectedCuratedCorpusItemConnection!
 
     """
-    Retrieves a list of Approved Items that are scheduled to appear on New Tab.
+    Retrieves a list of Approved Items that are scheduled to appear on a Scheduled Surface.
     """
     getScheduledCuratedCorpusItems(
         """
-        Required arguments to narrow down scheduled items to a specific New Tab Feed
+        Required arguments to narrow down scheduled items to a specific Scheduled Surface
         between the supplied start and end dates.
         """
         filters: ScheduledCuratedCorpusItemsFilterInput!
@@ -645,14 +646,14 @@ type Query {
     ): ApprovedCuratedCorpusItem
 
     """
-    Retrieves all NewTabs available to the given SSO user. Requires an Authorization header.
+    Retrieves all ScheduledSurfaces available to the given SSO user. Requires an Authorization header.
     """
-    getNewTabsForUser: [NewTab!]!
+    getScheduledSurfacesForUser: [ScheduledSurface!]!
 }
 
 type Mutation {
     """
-    Creates an Approved Item and optionally schedules it to appear on New Tab.
+    Creates an Approved Item and optionally schedules it to appear on a Scheduled Surface.
     """
     createApprovedCuratedCorpusItem(
         data: CreateApprovedCuratedCorpusItemInput!
@@ -680,14 +681,14 @@ type Mutation {
     ): ApprovedCuratedCorpusItem!
 
     """
-    Creates a New Tab Scheduled Item.
+    Creates a Scheduled Surface Scheduled Item.
     """
     createScheduledCuratedCorpusItem(
         data: CreateScheduledCuratedCorpusItemInput!
     ): ScheduledCuratedCorpusItem!
 
     """
-    Deletes an item from New Tab Schedule.
+    Deletes an item from a Scheduled Surface.
     """
     deleteScheduledCuratedCorpusItem(
         data: DeleteScheduledCuratedCorpusItemInput!

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -1,7 +1,7 @@
 import { DateResolver } from 'graphql-scalars';
 import { UnixTimestampResolver } from './fields/UnixTimestamp';
 import { getApprovedItems, getApprovedItemByUrl } from './queries/ApprovedItem';
-import { getNewTabsForUser } from './queries/NewTab';
+import { getScheduledSurfacesForUser } from './queries/ScheduledSurface';
 import { getRejectedItems } from './queries/RejectedItem';
 import { getScheduledItems } from './queries/ScheduledItem';
 import {
@@ -31,10 +31,6 @@ export const resolvers = {
   RejectedCuratedCorpusItem: {
     createdAt: UnixTimestampResolver,
   },
-  NewTabFeed: {
-    createdAt: UnixTimestampResolver,
-    updatedAt: UnixTimestampResolver,
-  },
   ScheduledCuratedCorpusItem: {
     createdAt: UnixTimestampResolver,
     updatedAt: UnixTimestampResolver,
@@ -45,7 +41,7 @@ export const resolvers = {
     getRejectedCuratedCorpusItems: getRejectedItems,
     getScheduledCuratedCorpusItems: getScheduledItems,
     getApprovedCuratedCorpusItemByUrl: getApprovedItemByUrl,
-    getNewTabsForUser,
+    getScheduledSurfacesForUser: getScheduledSurfacesForUser,
   },
   // Mutations that we need in the admin interface
   Mutation: {

--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -205,7 +205,7 @@ describe('mutations: ApprovedItem', () => {
 
       // extra inputs
       input.scheduledDate = '2100-01-01';
-      input.newTabGuid = 'EN_US';
+      input.scheduledSurfaceGuid = 'NEW_TAB_EN_US';
 
       const result = await server.executeOperation({
         query: CREATE_APPROVED_ITEM,
@@ -221,7 +221,7 @@ describe('mutations: ApprovedItem', () => {
       // We only return the approved item here, so need to purge the scheduling
       // input values from the input before comparison.
       delete input.scheduledDate;
-      delete input.newTabGuid;
+      delete input.scheduledSurfaceGuid;
       expect(result.data?.createApprovedCuratedCorpusItem).to.deep.include(
         input
       );
@@ -255,14 +255,14 @@ describe('mutations: ApprovedItem', () => {
       ).to.not.be.null;
     });
 
-    it('should not create a scheduled entry for an approved item with invalid New Tab id supplied', async () => {
+    it('should not create a scheduled entry for an approved item with invalid Scheduled Surface GUID supplied', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
       eventEmitter.on(ReviewedCorpusItemEventType.ADD_ITEM, eventTracker);
 
       // extra inputs
       input.scheduledDate = '2100-01-01';
-      input.newTabGuid = 'RECSAPI';
+      input.scheduledSurfaceGuid = 'RECSAPI';
 
       const result = await server.executeOperation({
         query: CREATE_APPROVED_ITEM,
@@ -276,7 +276,7 @@ describe('mutations: ApprovedItem', () => {
       // And there is the right error from the resolvers
       if (result.errors) {
         expect(result.errors[0].message).to.contain(
-          `Cannot create a scheduled entry with New Tab GUID of "${input.newTabGuid}".`
+          `Cannot create a scheduled entry with Scheduled Surface GUID of "${input.scheduledSurfaceGuid}".`
         );
         expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
       }
@@ -432,7 +432,7 @@ describe('mutations: ApprovedItem', () => {
       expect(eventTracker.callCount).to.equal(0);
     });
 
-    it('should fail if approved item has New Tab scheduled entries', async () => {
+    it('should fail if approved item has Scheduled Surface scheduled entries', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
       eventEmitter.on(ReviewedCorpusItemEventType.REMOVE_ITEM, eventTracker);
@@ -444,11 +444,11 @@ describe('mutations: ApprovedItem', () => {
         language: 'en',
       });
 
-      // Add an entry to a New Tab - approved item now can't be deleted
+      // Add an entry to a Scheduled Surface - approved item now can't be deleted
       // for data integrity reasons.
       await createScheduledItemHelper(db, {
         approvedItem: item,
-        newTabGuid: 'EN_US',
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
       });
 
       const input: RejectApprovedItemInput = {

--- a/src/admin/resolvers/mutations/ApprovedItem.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.ts
@@ -13,14 +13,14 @@ import {
 } from '../../../events/types';
 import { uploadImageToS3 } from '../../aws/upload';
 import {
-  newTabAllowedValues,
+  scheduledSurfaceAllowedValues,
   ApprovedItemS3ImageUrl,
 } from '../../../shared/types';
 import { CreateRejectedItemInput } from '../../../database/types';
 
 /**
  * Creates an approved curated item with data supplied. Optionally, schedules the freshly
- * created item to go onto New Tab for the date provided.
+ * created item to go onto Scheduled Surface for the date provided.
  *
  * @param parent
  * @param data
@@ -32,15 +32,15 @@ export async function createApprovedItem(
   { data },
   context
 ): Promise<ApprovedItem> {
-  const { scheduledDate, newTabGuid, ...approvedItemData } = data;
+  const { scheduledDate, scheduledSurfaceGuid, ...approvedItemData } = data;
 
   if (
     scheduledDate &&
-    newTabGuid &&
-    !newTabAllowedValues.includes(newTabGuid)
+    scheduledSurfaceGuid &&
+    !scheduledSurfaceAllowedValues.includes(scheduledSurfaceGuid)
   ) {
     throw new UserInputError(
-      `Cannot create a scheduled entry with New Tab GUID of "${data.newTabGuid}".`
+      `Cannot create a scheduled entry with Scheduled Surface GUID of "${data.scheduledSurfaceGuid}".`
     );
   }
 
@@ -51,13 +51,13 @@ export async function createApprovedItem(
     approvedItem
   );
 
-  if (scheduledDate && newTabGuid) {
+  if (scheduledDate && scheduledSurfaceGuid) {
     // Note that we create a scheduled item but don't return it
     // in the mutation response. Need to evaluate if we do need to return it
     // alongside the approved item.
     const scheduledItem = await createScheduledItem(context.db, {
       approvedItemExternalId: approvedItem.externalId,
-      newTabGuid,
+      scheduledSurfaceGuid,
       scheduledDate,
     });
 

--- a/src/admin/resolvers/mutations/ScheduledItem.integration.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.integration.ts
@@ -37,7 +37,7 @@ describe('mutations: ScheduledItem', () => {
   });
 
   describe('createScheduledCuratedCorpusItem mutation', () => {
-    it('should fail on invalid New Tab Feed ID', async () => {
+    it('should fail on invalid Scheduled Surface GUID', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
       eventEmitter.on(ScheduledCorpusItemEventType.ADD_SCHEDULE, eventTracker);
@@ -47,7 +47,7 @@ describe('mutations: ScheduledItem', () => {
       });
       const input: CreateScheduledItemInput = {
         approvedItemExternalId: approvedItem.externalId,
-        newTabGuid: 'RECSAPI',
+        scheduledSurfaceGuid: 'RECSAPI',
         scheduledDate: '2100-01-01',
       };
 
@@ -62,7 +62,7 @@ describe('mutations: ScheduledItem', () => {
       // And there is the correct error from the resolvers
       if (result.errors) {
         expect(result.errors[0].message).to.contain(
-          `Cannot create a scheduled entry with New Tab GUID of "RECSAPI".`
+          `Cannot create a scheduled entry with Scheduled Surface GUID of "RECSAPI".`
         );
         expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
       }
@@ -78,7 +78,7 @@ describe('mutations: ScheduledItem', () => {
 
       const input: CreateScheduledItemInput = {
         approvedItemExternalId: 'not-a-valid-id-at-all',
-        newTabGuid: 'EN_US',
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
         scheduledDate: '2100-01-01',
       };
 
@@ -103,7 +103,7 @@ describe('mutations: ScheduledItem', () => {
       expect(eventTracker.callCount).to.equal(0);
     });
 
-    it('should fail if story is already scheduled for given New Tab/date combination', async () => {
+    it('should fail if story is already scheduled for given Scheduled Surface/date combination', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
       eventEmitter.on(ScheduledCorpusItemEventType.ADD_SCHEDULE, eventTracker);
@@ -116,7 +116,7 @@ describe('mutations: ScheduledItem', () => {
       // create a scheduled entry for this item
       const existingScheduledEntry = await createScheduledItemHelper(db, {
         approvedItem: item,
-        newTabGuid: 'EN_US',
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
       });
 
       // This is the date format for the GraphQL mutation.
@@ -134,7 +134,7 @@ describe('mutations: ScheduledItem', () => {
       // as the scheduled entry created above.
       const input: CreateScheduledItemInput = {
         approvedItemExternalId: item.externalId,
-        newTabGuid: existingScheduledEntry.newTabGuid,
+        scheduledSurfaceGuid: existingScheduledEntry.scheduledSurfaceGuid,
         scheduledDate,
       };
 
@@ -148,7 +148,7 @@ describe('mutations: ScheduledItem', () => {
       // Expecting to see a custom error message from the resolver
       if (result.errors) {
         expect(result.errors[0].message).to.contain(
-          `This story is already scheduled to appear on EN_US on ${displayDate}.`
+          `This story is already scheduled to appear on NEW_TAB_EN_US on ${displayDate}.`
         );
         expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
       }
@@ -168,7 +168,7 @@ describe('mutations: ScheduledItem', () => {
 
       const input: CreateScheduledItemInput = {
         approvedItemExternalId: approvedItem.externalId,
-        newTabGuid: 'EN_US',
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
         scheduledDate: '2100-01-01',
       };
 
@@ -253,7 +253,7 @@ describe('mutations: ScheduledItem', () => {
       expect(eventTracker.callCount).to.equal(0);
     });
 
-    it('should delete an item scheduled for New Tab and return deleted data', async () => {
+    it('should delete an item scheduled for a Scheduled Surface and return deleted data', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
       eventEmitter.on(
@@ -266,7 +266,7 @@ describe('mutations: ScheduledItem', () => {
       });
 
       const scheduledItem = await createScheduledItemHelper(db, {
-        newTabGuid: 'EN_US',
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
         approvedItem,
       });
 

--- a/src/admin/resolvers/mutations/ScheduledItem.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.ts
@@ -3,13 +3,13 @@ import {
   createScheduledItem as dbCreateScheduledItem,
 } from '../../../database/mutations';
 import { ScheduledItem } from '../../../database/types';
-import { newTabAllowedValues } from '../../../shared/types';
+import { scheduledSurfaceAllowedValues } from '../../../shared/types';
 import { ScheduledCorpusItemEventType } from '../../../events/types';
 import { UserInputError } from 'apollo-server';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
 
 /**
- * Deletes an item from the New Tab schedule.
+ * Deletes an item from the Scheduled Surface schedule.
  *
  * @param parent
  * @param data
@@ -35,9 +35,9 @@ export async function createScheduledItem(
   { data },
   context
 ): Promise<ScheduledItem> {
-  if (!newTabAllowedValues.includes(data.newTabGuid)) {
+  if (!scheduledSurfaceAllowedValues.includes(data.scheduledSurfaceGuid)) {
     throw new UserInputError(
-      `Cannot create a scheduled entry with New Tab GUID of "${data.newTabGuid}".`
+      `Cannot create a scheduled entry with Scheduled Surface GUID of "${data.scheduledSurfaceGuid}".`
     );
   }
 
@@ -59,7 +59,7 @@ export async function createScheduledItem(
     ) {
       throw new UserInputError(
         `This story is already scheduled to appear on ${
-          data.newTabGuid
+          data.scheduledSurfaceGuid
         } on ${data.scheduledDate.toLocaleString('en-US', {
           dateStyle: 'medium',
         })}.`

--- a/src/admin/resolvers/queries/ScheduledItem.integration.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.integration.ts
@@ -29,7 +29,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
           title: `Batch 1, Story #${i + 1}`,
         });
         await createScheduledItemHelper(db, {
-          newTabGuid: 'EN_US',
+          scheduledSurfaceGuid: 'NEW_TAB_EN_US',
           approvedItem,
           scheduledDate: new Date('2050-01-01').toISOString(),
         });
@@ -41,7 +41,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
           title: `Batch 2, Story #${i + 1}`,
         });
         await createScheduledItemHelper(db, {
-          newTabGuid: 'EN_US',
+          scheduledSurfaceGuid: 'NEW_TAB_EN_US',
           approvedItem,
           scheduledDate: new Date('2025-05-05').toISOString(),
         });
@@ -53,7 +53,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
         query: GET_SCHEDULED_ITEMS,
         variables: {
           filters: {
-            newTabGuid: 'EN_US',
+            scheduledSurfaceGuid: 'NEW_TAB_EN_US',
             startDate: '2000-01-01',
             endDate: '2050-12-31',
           },
@@ -75,7 +75,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
         query: GET_SCHEDULED_ITEMS,
         variables: {
           filters: {
-            newTabGuid: 'EN_US',
+            scheduledSurfaceGuid: 'NEW_TAB_EN_US',
             startDate: '2000-01-01',
             endDate: '2050-12-31',
           },
@@ -118,7 +118,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
         query: GET_SCHEDULED_ITEMS,
         variables: {
           filters: {
-            newTabGuid: 'EN_US',
+            scheduledSurfaceGuid: 'NEW_TAB_EN_US',
             startDate: '2000-01-01',
             endDate: '2050-12-31',
           },
@@ -139,14 +139,14 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       expect(resultArray[1].scheduledDate).to.equal('2050-01-01');
     });
 
-    it('should fail on non-existent New Tab ID', async () => {
+    it('should fail on non-existent Scheduled Surface GUID', async () => {
       const invalidId = 'not-a-valid-id-by-any-means';
 
       const result = await server.executeOperation({
         query: GET_SCHEDULED_ITEMS,
         variables: {
           filters: {
-            newTabGuid: invalidId,
+            scheduledSurfaceGuid: invalidId,
             startDate: '2000-01-01',
             endDate: '2050-12-31',
           },

--- a/src/admin/resolvers/queries/ScheduledItem.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.ts
@@ -2,7 +2,7 @@ import { getScheduledItems as dbGetScheduledItems } from '../../../database/quer
 import { ScheduledItemsResult } from '../../../database/types';
 
 /**
- * Retrieves a list of Approved Items that are scheduled to appear on New Tab
+ * Retrieves a list of Approved Items that are scheduled to appear on a Scheduled Surface
  *
  */
 export async function getScheduledItems(

--- a/src/admin/resolvers/queries/ScheduledSurface.integration.ts
+++ b/src/admin/resolvers/queries/ScheduledSurface.integration.ts
@@ -4,7 +4,7 @@ import { GET_SCHEDULED_SURFACES_FOR_USER } from './sample-queries.gql';
 import { MozillaAccessGroup } from '../../../shared/types';
 
 describe('queries: ScheduledSurface', () => {
-  describe('getNewTabsForUser query', () => {
+  describe('getScheduledSurfacesForUser query', () => {
     it('should return all available surfaces for read-only users', async () => {
       const headers = {
         name: 'Test User',
@@ -19,9 +19,9 @@ describe('queries: ScheduledSurface', () => {
         query: GET_SCHEDULED_SURFACES_FOR_USER,
       });
 
-      const scheduledSurfaces = data?.getNewTabsForUser;
+      const scheduledSurfaces = data?.getScheduledSurfacesForUser;
 
-      expect(scheduledSurfaces).to.have.lengthOf(4);
+      expect(scheduledSurfaces).to.have.lengthOf(6);
 
       scheduledSurfaces.forEach((scheduledSurface) => {
         expect(scheduledSurface.guid).not.to.be.undefined;
@@ -47,9 +47,9 @@ describe('queries: ScheduledSurface', () => {
         query: GET_SCHEDULED_SURFACES_FOR_USER,
       });
 
-      const scheduledSurfaces = data?.getNewTabsForUser;
+      const scheduledSurfaces = data?.getScheduledSurfacesForUser;
 
-      expect(scheduledSurfaces).to.have.lengthOf(4);
+      expect(scheduledSurfaces).to.have.lengthOf(6);
 
       scheduledSurfaces.forEach((scheduledSurface) => {
         expect(scheduledSurface.guid).not.to.be.undefined;
@@ -61,7 +61,7 @@ describe('queries: ScheduledSurface', () => {
       await server.stop();
     });
 
-    it('should return a single new tab for users with access to one new tab', async () => {
+    it('should return a single surface for users with access to one scheduled surface', async () => {
       const headers = {
         name: 'Test User',
         username: 'test.user@test.com',
@@ -75,15 +75,15 @@ describe('queries: ScheduledSurface', () => {
         query: GET_SCHEDULED_SURFACES_FOR_USER,
       });
 
-      const scheduledSurfaces = data?.getNewTabsForUser;
+      const scheduledSurfaces = data?.getScheduledSurfacesForUser;
 
       expect(scheduledSurfaces).to.have.lengthOf(1);
-      expect(scheduledSurfaces[0].guid).to.equal('EN_US');
+      expect(scheduledSurfaces[0].guid).to.equal('NEW_TAB_EN_US');
 
       await server.stop();
     });
 
-    it('should return a limited set of new tabs for users with limited new tab access', async () => {
+    it('should return a limited set of scheduled surfaces for users with limited scheduled surface access', async () => {
       const headers = {
         name: 'Test User',
         username: 'test.user@test.com',
@@ -97,11 +97,11 @@ describe('queries: ScheduledSurface', () => {
         query: GET_SCHEDULED_SURFACES_FOR_USER,
       });
 
-      const scheduledSurfaces = data?.getNewTabsForUser;
+      const scheduledSurfaces = data?.getScheduledSurfacesForUser;
 
       expect(scheduledSurfaces).to.have.lengthOf(2);
-      expect(scheduledSurfaces[0].guid).to.equal('EN_US');
-      expect(scheduledSurfaces[1].guid).to.equal('DE_DE');
+      expect(scheduledSurfaces[0].guid).to.equal('NEW_TAB_EN_US');
+      expect(scheduledSurfaces[1].guid).to.equal('NEW_TAB_DE_DE');
 
       await server.stop();
     });
@@ -120,7 +120,7 @@ describe('queries: ScheduledSurface', () => {
         query: GET_SCHEDULED_SURFACES_FOR_USER,
       });
 
-      const scheduledSurfaces = data?.getNewTabsForUser;
+      const scheduledSurfaces = data?.getScheduledSurfacesForUser;
 
       expect(scheduledSurfaces).to.have.lengthOf(0);
 

--- a/src/admin/resolvers/queries/ScheduledSurface.ts
+++ b/src/admin/resolvers/queries/ScheduledSurface.ts
@@ -1,23 +1,23 @@
 import {
   AccessGroupToScheduledSurfaceMap,
   MozillaAccessGroup,
-  NewTab,
-  NewTabs,
+  ScheduledSurface,
+  ScheduledSurfaces,
 } from '../../../shared/types';
 
 /**
- * This query retrieves new tabs available to the given SSO user
+ * This query retrieves Scheduled Surfaces available to the given SSO user
  *
  * @param parent
  * @param args
  * @param db
  */
-export function getNewTabsForUser(
+export function getScheduledSurfacesForUser(
   parent,
   args,
   { authenticatedUser }
-): NewTab[] {
-  let scheduledSurfaces: NewTab[] = [];
+): ScheduledSurface[] {
+  let scheduledSurfaces: ScheduledSurface[] = [];
 
   // Return all scheduled surfaces for users with full access to the tool
   // and read-only users (otherwise the latter won't see anything???)
@@ -29,7 +29,7 @@ export function getNewTabsForUser(
   ) {
     // Somehow it doesn't seem right to be returning the entire shared data array
     // without assigning it to a variable first
-    scheduledSurfaces = NewTabs;
+    scheduledSurfaces = ScheduledSurfaces;
     // Return early - there is no need for extra access checks.
     return scheduledSurfaces;
   }

--- a/src/admin/resolvers/queries/sample-queries.gql.ts
+++ b/src/admin/resolvers/queries/sample-queries.gql.ts
@@ -83,7 +83,7 @@ export const GET_APPROVED_ITEM_BY_URL = gql`
 
 export const GET_SCHEDULED_SURFACES_FOR_USER = gql`
   query getScheduledSurfacesForUser {
-    getNewTabsForUser {
+    getScheduledSurfacesForUser {
       guid
       name
       utcOffset

--- a/src/database/mutations/ScheduledItem.ts
+++ b/src/database/mutations/ScheduledItem.ts
@@ -7,7 +7,7 @@ import {
 import { NotFoundError } from '@pocket-tools/apollo-utils';
 
 /**
- * This mutation adds a scheduled entry for a New Tab.
+ * This mutation adds a scheduled entry for a Scheduled Surface.
  *
  * @param db
  * @param data
@@ -16,7 +16,7 @@ export async function createScheduledItem(
   db: PrismaClient,
   data: CreateScheduledItemInput
 ): Promise<ScheduledItem> {
-  const { approvedItemExternalId, newTabGuid, scheduledDate } = data;
+  const { approvedItemExternalId, scheduledSurfaceGuid, scheduledDate } = data;
 
   const approvedItem = await db.approvedItem.findUnique({
     where: { externalId: approvedItemExternalId },
@@ -31,7 +31,7 @@ export async function createScheduledItem(
   return await db.scheduledItem.create({
     data: {
       approvedItemId: approvedItem.id,
-      newTabGuid,
+      scheduledSurfaceGuid,
       scheduledDate,
       // TODO: pass an actual user ID that comes from auth/JWT
       createdBy: 'sso-user',
@@ -43,7 +43,7 @@ export async function createScheduledItem(
 }
 
 /**
- * This mutation deletes a scheduled entry for a New Tab.
+ * This mutation deletes a scheduled entry for a Scheduled Surface.
  *
  * @param db
  * @param data

--- a/src/database/queries/ScheduledItem.ts
+++ b/src/database/queries/ScheduledItem.ts
@@ -16,13 +16,13 @@ export async function getScheduledItems(
   db: PrismaClient,
   filters: ScheduledItemFilterInput
 ): Promise<ScheduledItemsResult[]> {
-  const { newTabGuid, startDate, endDate } = filters;
+  const { scheduledSurfaceGuid, startDate, endDate } = filters;
 
   // Get a flat array of scheduled items from Prisma
   const items = await db.scheduledItem.findMany({
     orderBy: { scheduledDate: 'asc' },
     where: {
-      newTabGuid: { equals: newTabGuid },
+      scheduledSurfaceGuid: { equals: scheduledSurfaceGuid },
       scheduledDate: {
         gte: new Date(startDate),
         lte: new Date(endDate),
@@ -79,7 +79,7 @@ export async function getItemsForScheduledSurface(
   // Get a flat array of scheduled items from Prisma
   const items = await db.scheduledItem.findMany({
     where: {
-      newTabGuid: { equals: id },
+      scheduledSurfaceGuid: { equals: id },
       scheduledDate: date,
     },
     include: {
@@ -92,7 +92,7 @@ export async function getItemsForScheduledSurface(
   return items.map((scheduledItem) => {
     const item: ScheduledSurfaceItem = {
       id: scheduledItem.externalId,
-      surfaceId: scheduledItem.newTabGuid,
+      surfaceId: scheduledItem.scheduledSurfaceGuid,
       scheduledDate: DateTime.fromJSDate(scheduledItem.scheduledDate).toFormat(
         'yyyy-MM-dd'
       ),

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -49,9 +49,9 @@ export type CreateApprovedItemInput = ApprovedItemRequiredInput & {
   isCollection: boolean;
   isSyndicated: boolean;
   // These are optional properties for approving AND scheduling the item
-  // on New Tab at the same time.
+  // on a Scheduled Surface at the same time.
   scheduledDate?: string;
-  newTabGuid?: string;
+  scheduledSurfaceGuid?: string;
 };
 
 export type UpdateApprovedItemInput = Omit<
@@ -89,7 +89,7 @@ export type ScheduledItemsResult = {
 };
 
 export type ScheduledItemFilterInput = {
-  newTabGuid: string;
+  scheduledSurfaceGuid: string;
   startDate: string;
   endDate: string;
 };
@@ -100,7 +100,7 @@ export type DeleteScheduledItemInput = {
 
 export type CreateScheduledItemInput = {
   approvedItemExternalId: string;
-  newTabGuid: string;
+  scheduledSurfaceGuid: string;
   scheduledDate: string;
 };
 
@@ -125,7 +125,7 @@ export type ScheduledSurfaceItem = {
 };
 
 export type ScheduledSurface = {
-  // This is `newTabGuid` in the DB schema and Admin API
+  // This is `scheduledSurfaceGuid` in the DB schema and Admin API
   id: string;
   name: string;
   items?: ScheduledSurfaceItem[];

--- a/src/events/curatedCorpusEventEmitter.spec.ts
+++ b/src/events/curatedCorpusEventEmitter.spec.ts
@@ -62,7 +62,7 @@ describe('CuratedCorpusEventEmitter', () => {
       id: 1234,
       externalId: '1234-abc',
       approvedItemId: 123,
-      newTabGuid: 'EN-US',
+      scheduledSurfaceGuid: 'NEW_TAB_EN_US',
       createdAt: new Date(),
       createdBy: '',
       updatedAt: new Date(),

--- a/src/events/snowplow/ScheduledItemSnowplowHandler.integration.ts
+++ b/src/events/snowplow/ScheduledItemSnowplowHandler.integration.ts
@@ -17,7 +17,7 @@ import { ScheduledItemSnowplowHandler } from './ScheduledItemSnowplowHandler';
 import { tracker } from './tracker';
 import { CuratedCorpusEventEmitter } from '../curatedCorpusEventEmitter';
 import { getUnixTimestamp } from '../../shared/utils';
-import { getNewTabByGuid, Topics } from '../../shared/types';
+import { getScheduledSurfaceByGuid, Topics } from '../../shared/types';
 import { ScheduledItem } from '../../database/types';
 
 /**
@@ -28,7 +28,7 @@ const scheduledCorpusItem: ScheduledItem = {
   id: 789,
   externalId: '789-xyz',
   approvedItemId: 123,
-  newTabGuid: 'EN_US',
+  scheduledSurfaceGuid: 'NEW_TAB_EN_US',
   scheduledDate: new Date('2030-01-01'),
   createdAt: new Date(),
   createdBy: 'Amy',
@@ -75,10 +75,12 @@ function assertValidSnowplowScheduledItemEvents(data) {
         url: scheduledCorpusItem.approvedItem.url,
 
         scheduled_at: getUnixTimestamp(scheduledCorpusItem.scheduledDate),
-        new_tab_id: scheduledCorpusItem.newTabGuid,
-        new_tab_name: getNewTabByGuid(scheduledCorpusItem.newTabGuid)?.name,
-        new_tab_feed_utc_offset: getNewTabByGuid(
-          scheduledCorpusItem.newTabGuid
+        new_tab_id: scheduledCorpusItem.scheduledSurfaceGuid,
+        new_tab_name: getScheduledSurfaceByGuid(
+          scheduledCorpusItem.scheduledSurfaceGuid
+        )?.name,
+        new_tab_feed_utc_offset: getScheduledSurfaceByGuid(
+          scheduledCorpusItem.scheduledSurfaceGuid
         )?.utcOffset.toString(),
         created_at: getUnixTimestamp(scheduledCorpusItem.createdAt),
         created_by: scheduledCorpusItem.createdBy,

--- a/src/events/snowplow/ScheduledItemSnowplowHandler.ts
+++ b/src/events/snowplow/ScheduledItemSnowplowHandler.ts
@@ -10,7 +10,7 @@ import {
   ScheduledCorpusItem,
 } from './schema';
 import { getUnixTimestamp } from '../../shared/utils';
-import { getNewTabByGuid } from '../../shared/types';
+import { getScheduledSurfaceByGuid } from '../../shared/types';
 import { CuratedCorpusEventEmitter } from '../curatedCorpusEventEmitter';
 
 type CuratedCorpusItemUpdateEvent = Omit<SelfDescribingJson, 'data'> & {
@@ -85,7 +85,7 @@ export class ScheduledItemSnowplowHandler extends CuratedCorpusSnowplowHandler {
         scheduled_at: getUnixTimestamp(item.scheduledDate),
         url: item.approvedItem.url,
         approved_corpus_item_external_id: item.approvedItem.externalId,
-        new_tab_id: item.newTabGuid,
+        new_tab_id: item.scheduledSurfaceGuid,
         created_at: getUnixTimestamp(item.createdAt),
         created_by: item.createdBy,
         updated_at: getUnixTimestamp(item.updatedAt),
@@ -93,14 +93,16 @@ export class ScheduledItemSnowplowHandler extends CuratedCorpusSnowplowHandler {
       },
     };
 
-    // Get the NewTab info
-    const newTab = getNewTabByGuid(item.newTabGuid);
+    // Get the ScheduledSurface info
+    const scheduledSurface = getScheduledSurfaceByGuid(
+      item.scheduledSurfaceGuid
+    );
 
-    if (newTab) {
+    if (scheduledSurface) {
       context.data = {
         ...context.data,
-        new_tab_name: newTab.name,
-        new_tab_feed_utc_offset: newTab.utcOffset.toString(),
+        new_tab_name: scheduledSurface.name,
+        new_tab_feed_utc_offset: scheduledSurface.utcOffset.toString(),
       };
     }
 

--- a/src/events/snowplow/schema.ts
+++ b/src/events/snowplow/schema.ts
@@ -1,3 +1,6 @@
+// TODO: ask kenny/d&l to update schema to reference scheduled surface instead of new tab,
+// then come back and update this file (and other related files, probably)
+
 // Helper types and enums used in the schema
 export type RejectionReason = { reason: string };
 
@@ -19,8 +22,8 @@ export type CuratedCorpusItemUpdate = {
     | 'reviewed_corpus_item_updated' // Item is updated in the corpus
     | 'reviewed_corpus_item_removed' // Item is removed from the approved corpus
     | 'reviewed_corpus_item_rejected' // Item is added to the rejected corpus
-    | 'scheduled_corpus_item_added' // Item is added to the new tab schedule
-    | 'scheduled_corpus_item_removed'; // Item is removed from the new tab schedule
+    | 'scheduled_corpus_item_added' // Item is added to the scheduled surface schedule
+    | 'scheduled_corpus_item_removed'; // Item is removed from the scheduled surface schedule
   object: 'reviewed_corpus_item' | 'scheduled_corpus_item';
 };
 
@@ -119,7 +122,7 @@ export type ReviewedCorpusItem = {
 };
 
 /**
- * A scheduled run in the new tab of a reviewed corpus item.
+ * A scheduled run in the scheduled surface of a reviewed corpus item.
  */
 export type ScheduledCorpusItem = {
   /**
@@ -128,8 +131,8 @@ export type ScheduledCorpusItem = {
    */
   object_version: ObjectVersion;
   /**
-   * A guid that identifies the new tab feed schedule, sometimes referred to
-   * as the new tab feed schedule's external_id.
+   * A guid that identifies the scheduled surface schedule, sometimes referred to
+   * as the scheduled surface schedule's external_id.
    */
   scheduled_corpus_item_external_id: string;
   /**
@@ -153,33 +156,33 @@ export type ScheduledCorpusItem = {
    */
   approved_corpus_item_external_id: string;
   /**
-   * A guid that identifies the new tab, e.g. 'EN_US'.
+   * A guid that identifies the scheduled surface, e.g. 'NEW_TAB_EN_US'.
    */
   new_tab_id: string;
   /**
-   * The name of the new tab feed.
+   * The name of the scheduled surface.
    */
   new_tab_name?: string;
   /**
-   * The time that the new tab feed is offset from UTC time.
+   * The time that the scheduled surface feed is offset from UTC time.
    */
   new_tab_feed_utc_offset?: string;
   /**
-   * The UTC unix timestamp (in seconds) for when the new tab feed schedule
+   * The UTC unix timestamp (in seconds) for when the scheduled surface schedule
    * was created.
    */
   created_at?: number;
   /**
-   * The curator who created the new tab feed schedule.
+   * The curator who created the scheduled surface schedule.
    */
   created_by?: string;
   /**
-   * The UTC unix timestamp (in seconds) for when the new tab feed schedule
+   * The UTC unix timestamp (in seconds) for when the scheduled surface schedule
    * was last updated.
    */
   updated_at?: number;
   /**
-   * The curator who most recently updated the new tab feed schedule.
+   * The curator who most recently updated the scheduled surface feed schedule.
    */
   updated_by?: string;
 };

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -33,7 +33,7 @@ export type ReviewedCorpusItemPayload = {
   reviewedCorpusItem: ApprovedItem | RejectedCuratedCorpusItem;
 };
 
-// Data for the events that are fired on updates to New Tab schedule
+// Data for the events that are fired on updates to Scheduled Surface schedule
 export type ScheduledCorpusItemPayload = {
   scheduledCorpusItem: ScheduledItem;
 };

--- a/src/public/resolvers/queries/ScheduledSurface.integration.ts
+++ b/src/public/resolvers/queries/ScheduledSurface.integration.ts
@@ -15,14 +15,14 @@ describe('queries: ScheduledSurface', () => {
   });
 
   describe('scheduledSurface query', () => {
-    it('should get New Tab metadata for a given GUID', async () => {
+    it('should get Scheduled Surface metadata for a given GUID', async () => {
       const { data } = await server.executeOperation({
         query: GET_SCHEDULED_SURFACE,
-        variables: { id: 'EN_GB' },
+        variables: { id: 'NEW_TAB_EN_GB' },
       });
 
-      expect(data?.scheduledSurface.id).to.equal('EN_GB');
-      expect(data?.scheduledSurface.name).to.equal('en-GB');
+      expect(data?.scheduledSurface.id).to.equal('NEW_TAB_EN_GB');
+      expect(data?.scheduledSurface.name).to.equal('New Tab (en-GB)');
     });
   });
 

--- a/src/public/resolvers/queries/ScheduledSurface.ts
+++ b/src/public/resolvers/queries/ScheduledSurface.ts
@@ -1,5 +1,5 @@
 import { ScheduledSurface } from '../../../database/types';
-import { NewTabs } from '../../../shared/types';
+import { ScheduledSurfaces } from '../../../shared/types';
 import { UserInputError } from 'apollo-server';
 
 /**
@@ -13,19 +13,19 @@ export async function getScheduledSurface(
   const { id } = args;
 
   // Data retrieval is super simple here given that we store shared data,
-  // such as New Tab values, as hardcoded values at the moment.
-  const newTab = NewTabs.find((newTab) => {
-    return newTab.guid === id;
+  // such as Scheduled Surface values, as hardcoded values at the moment.
+  const surface = ScheduledSurfaces.find((surface) => {
+    return surface.guid === id;
   });
 
-  if (!newTab) {
+  if (!surface) {
     throw new UserInputError(
       `Could not find Scheduled Surface with id of "${id}".`
     );
   }
 
   return {
-    id: newTab.guid,
-    name: newTab.name,
+    id: surface.guid,
+    name: surface.name,
   };
 }

--- a/src/public/resolvers/queries/ScheduledSurfaceItem.integration.ts
+++ b/src/public/resolvers/queries/ScheduledSurfaceItem.integration.ts
@@ -29,7 +29,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
           title: `Batch 1, Story #${i + 1}`,
         });
         await createScheduledItemHelper(db, {
-          newTabGuid: 'EN_US',
+          scheduledSurfaceGuid: 'NEW_TAB_EN_US',
           approvedItem,
           scheduledDate: new Date('2050-01-01').toISOString(),
         });
@@ -41,7 +41,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
           title: `Batch 2, Story #${i + 1}`,
         });
         await createScheduledItemHelper(db, {
-          newTabGuid: 'EN_US',
+          scheduledSurfaceGuid: 'NEW_TAB_EN_US',
           approvedItem,
           scheduledDate: new Date('2025-05-05').toISOString(),
         });
@@ -52,7 +52,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       const result = await server.executeOperation({
         query: GET_SCHEDULED_SURFACE_WITH_ITEMS,
         variables: {
-          id: 'EN_US',
+          id: 'NEW_TAB_EN_US',
           date: '2050-01-01',
         },
       });
@@ -68,7 +68,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       const result = await server.executeOperation({
         query: GET_SCHEDULED_SURFACE_WITH_ITEMS,
         variables: {
-          id: 'EN_US',
+          id: 'NEW_TAB_EN_US',
           date: '2025-05-05',
         },
       });
@@ -81,7 +81,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
 
       // Scalar properties of the first item
       expect(item.id).not.to.be.null;
-      expect(item.surfaceId).to.equal('EN_US');
+      expect(item.surfaceId).to.equal('NEW_TAB_EN_US');
       expect(item.scheduledDate).to.equal('2025-05-05');
 
       // The underlying Corpus Item
@@ -98,7 +98,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       const result = await server.executeOperation({
         query: GET_SCHEDULED_SURFACE_WITH_ITEMS,
         variables: {
-          id: 'EN_US',
+          id: 'NEW_TAB_EN_US',
           date: '2100-02-02',
         },
       });

--- a/src/public/resolvers/queries/ScheduledSurfaceItem.ts
+++ b/src/public/resolvers/queries/ScheduledSurfaceItem.ts
@@ -2,7 +2,7 @@ import { ScheduledSurfaceItem } from '../../../database/types';
 import { getItemsForScheduledSurface as dbGetItemsForScheduledSurface } from '../../../database/queries';
 
 /**
- * Pulls in scheduled items for a given date and surface (e.g., EN_US New Tab).
+ * Pulls in scheduled items for a given date and surface (e.g., NEW_TAB_EN_US).
  *
  * @param parent
  * @param args

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,9 +3,10 @@ export enum ProspectType {
   GLOBAL = 'GLOBAL',
   ORGANIC_TIMESPENT = 'ORGANIC_TIMESPENT',
   SYNDICATED = 'SYNDICATED',
+  TOP_SAVED = 'TOP_SAVED',
 }
 
-export type NewTab = {
+export type ScheduledSurface = {
   name: string;
   guid: string;
   utcOffset: number;
@@ -16,10 +17,10 @@ export type ApprovedItemS3ImageUrl = {
   url: string;
 };
 
-export const NewTabs: NewTab[] = [
+export const ScheduledSurfaces: ScheduledSurface[] = [
   {
-    name: 'en-US',
-    guid: 'EN_US',
+    name: 'New Tab (en-US)',
+    guid: 'NEW_TAB_EN_US',
     utcOffset: -500,
     prospectTypes: [
       ProspectType.GLOBAL,
@@ -28,32 +29,50 @@ export const NewTabs: NewTab[] = [
     ],
   },
   {
-    name: 'de-DE',
-    guid: 'DE_DE',
+    name: 'New Tab (de-DE)',
+    guid: 'NEW_TAB_DE_DE',
     utcOffset: 100,
     prospectTypes: [ProspectType.GLOBAL, ProspectType.ORGANIC_TIMESPENT],
   },
   {
-    name: 'en-GB',
-    guid: 'EN_GB',
+    name: 'New Tab (en-GB)',
+    guid: 'NEW_TAB_EN_GB',
     utcOffset: 0,
     prospectTypes: [ProspectType.GLOBAL, ProspectType.ORGANIC_TIMESPENT],
   },
   {
-    name: 'en-INTL',
-    guid: 'EN_INTL',
+    name: 'New Tab (en-INTL)',
+    guid: 'NEW_TAB_EN_INTL',
     utcOffset: 530,
     prospectTypes: [ProspectType.GLOBAL, ProspectType.ORGANIC_TIMESPENT],
+  },
+  {
+    name: 'Pocket Hits (en-US)',
+    guid: 'POCKET_HITS_EN_US',
+    utcOffset: -500,
+    prospectTypes: [ProspectType.TOP_SAVED],
+  },
+  {
+    name: 'Pocket Hits (de-DE)',
+    guid: 'POCKET_HITS_DE_DE',
+    utcOffset: 100,
+    prospectTypes: [ProspectType.TOP_SAVED],
   },
 ];
 
 // Useful, cut down versions of the above
-export const newTabAllowedValues = NewTabs.map((newTab) => {
-  return newTab.guid;
-});
+export const scheduledSurfaceAllowedValues = ScheduledSurfaces.map(
+  (surface) => {
+    return surface.guid;
+  }
+);
 
-export const getNewTabByGuid = (guid: string): NewTab | undefined => {
-  return NewTabs.find((newTab: NewTab) => newTab.guid === guid);
+export const getScheduledSurfaceByGuid = (
+  guid: string
+): ScheduledSurface | undefined => {
+  return ScheduledSurfaces.find(
+    (surface: ScheduledSurface) => surface.guid === guid
+  );
 };
 
 export enum MozillaAccessGroup {
@@ -69,12 +88,26 @@ export enum MozillaAccessGroup {
 }
 
 export const AccessGroupToScheduledSurfaceMap: {
-  [key in MozillaAccessGroup]?: NewTab;
+  [key in MozillaAccessGroup]?: ScheduledSurface;
 } = {
-  [MozillaAccessGroup.NEW_TAB_CURATOR_ENUS]: getNewTabByGuid('EN_US'),
-  [MozillaAccessGroup.NEW_TAB_CURATOR_DEDE]: getNewTabByGuid('DE_DE'),
-  [MozillaAccessGroup.NEW_TAB_CURATOR_ENGB]: getNewTabByGuid('EN_GB'),
-  [MozillaAccessGroup.NEW_TAB_CURATOR_ENINTL]: getNewTabByGuid('EN_INTL'),
+  [MozillaAccessGroup.NEW_TAB_CURATOR_ENUS]:
+    getScheduledSurfaceByGuid('NEW_TAB_EN_US'),
+  [MozillaAccessGroup.NEW_TAB_CURATOR_DEDE]:
+    getScheduledSurfaceByGuid('NEW_TAB_DE_DE'),
+  [MozillaAccessGroup.NEW_TAB_CURATOR_ENGB]:
+    getScheduledSurfaceByGuid('NEW_TAB_EN_GB'),
+  [MozillaAccessGroup.NEW_TAB_CURATOR_ENINTL]:
+    getScheduledSurfaceByGuid('NEW_TAB_EN_INTL'),
+  [MozillaAccessGroup.NEW_TAB_CURATOR_ENGB]:
+    getScheduledSurfaceByGuid('NEW_TAB_EN_GB'),
+  [MozillaAccessGroup.NEW_TAB_CURATOR_ENINTL]:
+    getScheduledSurfaceByGuid('NEW_TAB_EN_INTL'),
+  [MozillaAccessGroup.POCKET_HITS_CURATOR_DEDE]: getScheduledSurfaceByGuid(
+    'POCKET_HITS_CURATOR_DEDE'
+  ),
+  [MozillaAccessGroup.POCKET_HITS_CURATOR_ENUS]: getScheduledSurfaceByGuid(
+    'POCKET_HITS_CURATOR_ENUS'
+  ),
 };
 
 export enum Topics {

--- a/src/test/helpers/createScheduledItemHelper.integration.ts
+++ b/src/test/helpers/createScheduledItemHelper.integration.ts
@@ -11,7 +11,7 @@ const db = new PrismaClient();
 
 describe('createScheduledItemHelper', () => {
   let approvedItem: ApprovedItem;
-  let newTabGuid: string;
+  let scheduledSurfaceGuid: string;
 
   beforeEach(async () => {
     await clearDb(db);
@@ -19,7 +19,7 @@ describe('createScheduledItemHelper', () => {
     approvedItem = await createApprovedItemHelper(db, {
       title: 'What even is time?',
     });
-    newTabGuid = 'DE_DE';
+    scheduledSurfaceGuid = 'NEW_TAB_DE_DE';
   });
 
   afterAll(async () => {
@@ -29,14 +29,14 @@ describe('createScheduledItemHelper', () => {
   it('should create a scheduled item with required props supplied', async () => {
     const data: CreateScheduledItemHelperInput = {
       approvedItem,
-      newTabGuid,
+      scheduledSurfaceGuid: scheduledSurfaceGuid,
     };
 
     const item: ScheduledItem = await createScheduledItemHelper(db, data);
 
     // Expect to see the data we passed to the helper
     expect(item.approvedItemId).toBe(approvedItem.id);
-    expect(item.newTabGuid).toBe(newTabGuid);
+    expect(item.scheduledSurfaceGuid).toBe(scheduledSurfaceGuid);
 
     // Expect to see the remaining fields filled in for us
     expect(item.createdBy).toBeTruthy();
@@ -48,14 +48,14 @@ describe('createScheduledItemHelper', () => {
       createdBy: faker.fake('auth-provider|test@example.com'),
       scheduledDate: '2022-01-01T00:00:00.000Z',
       approvedItem,
-      newTabGuid,
+      scheduledSurfaceGuid: scheduledSurfaceGuid,
     };
 
     const item: ScheduledItem = await createScheduledItemHelper(db, data);
 
     // Expect to see everything as specified to the helper
     expect(item.approvedItemId).toBe(approvedItem.id);
-    expect(item.newTabGuid).toBe(newTabGuid);
+    expect(item.scheduledSurfaceGuid).toBe(scheduledSurfaceGuid);
     expect(item.createdBy).toBe(data.createdBy);
     expect(item.scheduledDate.toISOString()).toBe(data.scheduledDate);
   });

--- a/src/test/helpers/createScheduledItemHelper.ts
+++ b/src/test/helpers/createScheduledItemHelper.ts
@@ -6,7 +6,7 @@ import {
 } from '@prisma/client';
 import faker from 'faker';
 
-// the data required to create a scheduled item that goes onto new tab
+// the data required to create a scheduled item that goes onto a scheduled surface
 interface CreateScheduledItemHelperRequiredInput {
   approvedItem: ApprovedItem;
 }
@@ -14,7 +14,7 @@ interface CreateScheduledItemHelperRequiredInput {
 // optional information you can provide when creating a scheduled item
 interface CreateScheduledItemHelperOptionalInput {
   createdBy?: string;
-  newTabGuid?: string;
+  scheduledSurfaceGuid?: string;
   scheduledDate?: string;
 }
 
@@ -24,7 +24,7 @@ export type CreateScheduledItemHelperInput =
     CreateScheduledItemHelperOptionalInput;
 
 /**
- * A helper function that creates a sample scheduled item to go onto new tab
+ * A helper function that creates a sample scheduled item to go onto a scheduled surface
  * for testing or local development.
  * @param prisma
  * @param data
@@ -41,7 +41,7 @@ export async function createScheduledItemHelper(
       faker.date.soon(7).toISOString(),
       faker.date.recent(7).toISOString(),
     ]),
-    newTabGuid: 'EN_US',
+    scheduledSurfaceGuid: 'NEW_TAB_EN_US',
   };
 
   const inputs: Prisma.ScheduledItemCreateInput = {


### PR DESCRIPTION
## Goal

rename new tab to scheduled surface. update other shared data constructs.

- customized migration to get around mysql fk issue
- removed legacy NewTabFeed resolver

no functionality was changed, no tests were changed. the biggest question mark here is the db migration. locally, this required my db to be emptied. as we aren't in prod yet, i don't think this is a big risk, but wanted to call it out. definitely open to ideas there.

note that this will break the frontend, as the API has changed to reflect shared data. we should coordinate a frontend PR and deploy the two together.

## I'd love feedback/perspectives on:
- db migration

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1308