### PR TITLE
feat(auth): Add access control checks to ScheduledItem mutations [BACK-1173]

### DIFF
--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -162,12 +162,10 @@ describe('mutations: ApprovedItem', () => {
       expect(result.errors).not.to.be.null;
 
       // And there is the correct error from the resolvers
-      if (result.errors) {
-        expect(result.errors[0].message).to.contain(
-          `An approved item with the URL "${input.url}" already exists`
-        );
-        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
-      }
+      expect(result.errors?.[0].message).to.contain(
+        `An approved item with the URL "${input.url}" already exists`
+      );
+      expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
 
       // Check that the ADD_ITEM event was not fired
       expect(eventTracker.callCount).to.equal(0);
@@ -194,12 +192,10 @@ describe('mutations: ApprovedItem', () => {
       expect(result.errors).not.to.be.null;
 
       // And there is the correct error from the resolvers
-      if (result.errors) {
-        expect(result.errors[0].message).to.contain(
-          `A rejected item with the URL "${input.url}" already exists`
-        );
-        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
-      }
+      expect(result.errors?.[0].message).to.contain(
+        `A rejected item with the URL "${input.url}" already exists`
+      );
+      expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
 
       // Check that the ADD_ITEM event was not fired
       expect(eventTracker.callCount).to.equal(0);
@@ -282,12 +278,10 @@ describe('mutations: ApprovedItem', () => {
       expect(result.errors).not.to.be.null;
 
       // And there is the right error from the resolvers
-      if (result.errors) {
-        expect(result.errors[0].message).to.contain(
-          `Cannot create a scheduled entry with Scheduled Surface GUID of "${input.scheduledSurfaceGuid}".`
-        );
-        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
-      }
+      expect(result.errors?.[0].message).to.contain(
+        `Cannot create a scheduled entry with Scheduled Surface GUID of "${input.scheduledSurfaceGuid}".`
+      );
+      expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
 
       // Check that the ADD_ITEM event was not fired
       expect(eventTracker.callCount).to.equal(0);
@@ -429,12 +423,10 @@ describe('mutations: ApprovedItem', () => {
 
       expect(result.errors).not.to.be.null;
 
-      if (result.errors) {
-        expect(result.errors[0].message).to.equal(
-          `Could not find an approved item with external id of "${input.externalId}".`
-        );
-        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
-      }
+      expect(result.errors?.[0].message).to.equal(
+        `Could not find an approved item with external id of "${input.externalId}".`
+      );
+      expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
 
       // Check that the events were not fired
       expect(eventTracker.callCount).to.equal(0);
@@ -471,14 +463,12 @@ describe('mutations: ApprovedItem', () => {
 
       expect(result.errors).not.to.be.null;
 
-      if (result.errors) {
-        expect(result.errors[0].message).to.equal(
-          `Cannot remove item from approved corpus - scheduled entries exist.`
-        );
-        expect(result.errors[0].extensions?.code).to.equal(
-          'INTERNAL_SERVER_ERROR'
-        );
-      }
+      expect(result.errors?.[0].message).to.equal(
+        `Cannot remove item from approved corpus - scheduled entries exist.`
+      );
+      expect(result.errors?.[0].extensions?.code).to.equal(
+        'INTERNAL_SERVER_ERROR'
+      );
 
       // Check that the events were not fired
       expect(eventTracker.callCount).to.equal(0);

--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -2,12 +2,13 @@ import config from '../../../config';
 import { CuratedStatus } from '@prisma/client';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { db, getServer } from '../../../test/admin-server';
+import { db } from '../../../test/admin-server';
 import {
   clearDb,
   createApprovedItemHelper,
   createRejectedCuratedCorpusItemHelper,
   createScheduledItemHelper,
+  getServerWithMockedHeaders,
 } from '../../../test/helpers';
 import {
   CREATE_APPROVED_ITEM,
@@ -28,10 +29,17 @@ import {
 import { Upload } from 'graphql-upload';
 import { createReadStream, unlinkSync, writeFileSync } from 'fs';
 import { GET_REJECTED_ITEMS } from '../queries/sample-queries.gql';
+import { MozillaAccessGroup } from '../../../shared/types';
 
 describe('mutations: ApprovedItem', () => {
   const eventEmitter = new CuratedCorpusEventEmitter();
-  const server = getServer(eventEmitter);
+
+  const headers = {
+    name: 'Test User',
+    username: 'test.user@test.com',
+    groups: `group1,group2,${MozillaAccessGroup.SCHEDULED_SURFACE_CURATOR_FULL}`,
+  };
+  const server = getServerWithMockedHeaders(headers, eventEmitter);
 
   beforeAll(async () => {
     await server.start();

--- a/src/admin/resolvers/mutations/RejectedItem.integration.ts
+++ b/src/admin/resolvers/mutations/RejectedItem.integration.ts
@@ -136,12 +136,10 @@ describe('mutations: RejectedItem', () => {
       expect(result.errors).not.to.be.null;
 
       // And there is the correct error from the resolvers
-      if (result.errors) {
-        expect(result.errors[0].message).to.contain(
-          `A rejected item with the URL "${input.url}" already exists.`
-        );
-        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
-      }
+      expect(result.errors?.[0].message).to.contain(
+        `A rejected item with the URL "${input.url}" already exists.`
+      );
+      expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
 
       // Check that the REJECT_ITEM event was not fired
       expect(eventTracker.callCount).to.equal(0);
@@ -168,12 +166,10 @@ describe('mutations: RejectedItem', () => {
       expect(result.errors).not.to.be.null;
 
       // And there is the correct error from the resolvers
-      if (result.errors) {
-        expect(result.errors[0].message).to.contain(
-          `An approved item with the URL "${input.url}" already exists.`
-        );
-        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
-      }
+      expect(result.errors?.[0].message).to.contain(
+        `An approved item with the URL "${input.url}" already exists.`
+      );
+      expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
 
       // Check that the REJECT_ITEM event was not fired
       expect(eventTracker.callCount).to.equal(0);

--- a/src/admin/resolvers/mutations/RejectedItem.integration.ts
+++ b/src/admin/resolvers/mutations/RejectedItem.integration.ts
@@ -1,19 +1,27 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { db, getServer } from '../../../test/admin-server';
+import { db } from '../../../test/admin-server';
 import {
   clearDb,
   createApprovedItemHelper,
   createRejectedCuratedCorpusItemHelper,
+  getServerWithMockedHeaders,
 } from '../../../test/helpers';
 import { CREATE_REJECTED_ITEM } from './sample-mutations.gql';
 import { CreateRejectedItemInput } from '../../../database/types';
 import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
 import { ReviewedCorpusItemEventType } from '../../../events/types';
+import { MozillaAccessGroup } from '../../../shared/types';
 
 describe('mutations: RejectedItem', () => {
   const eventEmitter = new CuratedCorpusEventEmitter();
-  const server = getServer(eventEmitter);
+
+  const headers = {
+    name: 'Test User',
+    username: 'test.user@test.com',
+    groups: `group1,group2,${MozillaAccessGroup.SCHEDULED_SURFACE_CURATOR_FULL}`,
+  };
+  const server = getServerWithMockedHeaders(headers, eventEmitter);
 
   beforeAll(async () => {
     await server.start();

--- a/src/admin/resolvers/mutations/ScheduledItem.integration.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.integration.ts
@@ -68,12 +68,10 @@ describe('mutations: ScheduledItem', () => {
       expect(result.errors).not.to.be.null;
 
       // And there is the correct error from the resolvers
-      if (result.errors) {
-        expect(result.errors[0].message).to.contain(
-          `Cannot create a scheduled entry with Scheduled Surface GUID of "RECSAPI".`
-        );
-        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
-      }
+      expect(result.errors?.[0].message).to.contain(
+        `Cannot create a scheduled entry with Scheduled Surface GUID of "RECSAPI".`
+      );
+      expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
 
       // Check that the ADD_SCHEDULE event was not fired
       expect(eventTracker.callCount).to.equal(0);
@@ -98,14 +96,12 @@ describe('mutations: ScheduledItem', () => {
       expect(result.data).to.be.null;
 
       // And there is the correct error from the resolvers
-      if (result.errors) {
-        expect(result.errors[0].message).to.contain(
-          `Cannot create a scheduled entry: Approved Item with id "not-a-valid-id-at-all" does not exist.`
-        );
-        expect(result.errors[0].extensions?.code).to.equal(
-          'INTERNAL_SERVER_ERROR'
-        );
-      }
+      expect(result.errors?.[0].message).to.contain(
+        `Cannot create a scheduled entry: Approved Item with id "not-a-valid-id-at-all" does not exist.`
+      );
+      expect(result.errors?.[0].extensions?.code).to.equal(
+        'INTERNAL_SERVER_ERROR'
+      );
 
       // Check that the ADD_SCHEDULE event was not fired
       expect(eventTracker.callCount).to.equal(0);
@@ -154,12 +150,10 @@ describe('mutations: ScheduledItem', () => {
       expect(result.data).to.be.null;
 
       // Expecting to see a custom error message from the resolver
-      if (result.errors) {
-        expect(result.errors[0].message).to.contain(
-          `This story is already scheduled to appear on NEW_TAB_EN_US on ${displayDate}.`
-        );
-        expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
-      }
+      expect(result.errors?.[0].message).to.contain(
+        `This story is already scheduled to appear on NEW_TAB_EN_US on ${displayDate}.`
+      );
+      expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
 
       // Check that the ADD_SCHEDULE event was not fired
       expect(eventTracker.callCount).to.equal(0);
@@ -230,7 +224,7 @@ describe('mutations: ScheduledItem', () => {
       const headers = {
         name: 'Test User',
         username: 'test.user@test.com',
-        groups: `group1,group2,no-access-for-you`,
+        groups: `group1,group2,${MozillaAccessGroup.READONLY}`,
       };
 
       const server = getServerWithMockedHeaders(headers);
@@ -256,10 +250,8 @@ describe('mutations: ScheduledItem', () => {
 
       expect(result.errors).not.to.be.null;
 
-      if (result.errors) {
-        // And there is an access denied error
-        expect(result.errors[0].message).to.contain(ACCESS_DENIED_ERROR);
-      }
+      // And there is an access denied error
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
 
       await server.stop();
     });
@@ -294,10 +286,8 @@ describe('mutations: ScheduledItem', () => {
 
       expect(result.errors).not.to.be.null;
 
-      if (result.errors) {
-        // And there is an access denied error
-        expect(result.errors[0].message).to.contain(ACCESS_DENIED_ERROR);
-      }
+      // And there is an access denied error
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
 
       await server.stop();
     });
@@ -358,14 +348,12 @@ describe('mutations: ScheduledItem', () => {
       expect(result.data).to.be.null;
 
       // And there is the correct error from the resolvers
-      if (result.errors) {
-        expect(result.errors[0].message).to.contain(
-          `Item with ID of '${input.externalId}' could not be found.`
-        );
-        expect(result.errors[0].extensions?.code).to.equal(
-          'INTERNAL_SERVER_ERROR'
-        );
-      }
+      expect(result.errors?.[0].message).to.contain(
+        `Item with ID of '${input.externalId}' could not be found.`
+      );
+      expect(result.errors?.[0].extensions?.code).to.equal(
+        'INTERNAL_SERVER_ERROR'
+      );
 
       // Check that the REMOVE_SCHEDULE event was not fired
       expect(eventTracker.callCount).to.equal(0);
@@ -447,7 +435,7 @@ describe('mutations: ScheduledItem', () => {
       const headers = {
         name: 'Test User',
         username: 'test.user@test.com',
-        groups: `group1,group2,no-access-for-you`,
+        groups: `group1,group2,${MozillaAccessGroup.READONLY}`,
       };
 
       const server = getServerWithMockedHeaders(headers);
@@ -472,10 +460,8 @@ describe('mutations: ScheduledItem', () => {
 
       expect(result.errors).not.to.be.null;
 
-      if (result.errors) {
-        // And there is an access denied error
-        expect(result.errors[0].message).to.contain(ACCESS_DENIED_ERROR);
-      }
+      // And there is an access denied error
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
 
       await server.stop();
     });
@@ -509,10 +495,8 @@ describe('mutations: ScheduledItem', () => {
 
       expect(result.errors).not.to.be.null;
 
-      if (result.errors) {
-        // And there is an access denied error
-        expect(result.errors[0].message).to.contain(ACCESS_DENIED_ERROR);
-      }
+      // And there is an access denied error
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
 
       await server.stop();
     });

--- a/src/admin/resolvers/mutations/ScheduledItem.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.ts
@@ -12,6 +12,7 @@ import { UserInputError } from 'apollo-server';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
 import { AuthenticationError } from 'apollo-server-errors';
 import { IContext } from '../../context';
+import { NotFoundError } from '@pocket-tools/apollo-utils';
 
 /**
  * Deletes an item from the Scheduled Surface schedule.
@@ -26,8 +27,8 @@ export async function deleteScheduledItem(
   context: IContext
 ): Promise<ScheduledItem> {
   // Need to fetch the item first to check access privileges.
-  // Could we make it easier/not hit the DB by passing the Scheduled Surface GUID
-  // as a required input to the delete mutation?
+  // Note that we do not worry here about an extra hit to the DB
+  // as load on this service will be low.
   const item = await context.db.scheduledItem.findUnique({
     where: { externalId: data.externalId },
   });

--- a/src/admin/resolvers/mutations/ScheduledItem.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.ts
@@ -12,7 +12,6 @@ import { UserInputError } from 'apollo-server';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
 import { AuthenticationError } from 'apollo-server-errors';
 import { IContext } from '../../context';
-import { NotFoundError } from '@pocket-tools/apollo-utils';
 
 /**
  * Deletes an item from the Scheduled Surface schedule.

--- a/src/admin/resolvers/queries/ScheduledItem.integration.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.integration.ts
@@ -155,14 +155,10 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
 
       expect(result.errors).not.to.be.null;
 
-      // typescript needs this check bc result.errors _could_ be empty
-      // (we check above to ensure it is not)
-      if (result.errors) {
-        expect(result.errors.length).to.equal(1);
-        expect(result.errors[0].message).to.equal(
-          'not-a-valid-id-by-any-means is not a valid Scheduled Surface GUID'
-        );
-      }
+      expect(result.errors?.length).to.equal(1);
+      expect(result.errors?.[0].message).to.equal(
+        'not-a-valid-id-by-any-means is not a valid Scheduled Surface GUID'
+      );
     });
 
     it('should fail on non-existent Scheduled Surface GUID', async () => {
@@ -180,14 +176,10 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
 
       expect(result.errors).not.to.be.null;
 
-      // typescript needs this check bc result.errors _could_ be empty
-      // (we check above to ensure it is not)
-      if (result.errors) {
-        expect(result.errors.length).to.equal(1);
-        expect(result.errors[0].message).to.equal(
-          ' is not a valid Scheduled Surface GUID'
-        );
-      }
+      expect(result.errors?.length).to.equal(1);
+      expect(result.errors?.[0].message).to.equal(
+        ' is not a valid Scheduled Surface GUID'
+      );
     });
   });
 });

--- a/src/admin/resolvers/queries/ScheduledItem.integration.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.integration.ts
@@ -139,7 +139,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       expect(resultArray[1].scheduledDate).to.equal('2050-01-01');
     });
 
-    it('should fail on non-existent Scheduled Surface GUID', async () => {
+    it('should fail on invalid Scheduled Surface GUID', async () => {
       const invalidId = 'not-a-valid-id-by-any-means';
 
       const result = await server.executeOperation({
@@ -153,9 +153,41 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
         },
       });
 
-      // Expect to see no data returned, and no errors either
-      expect(result.errors).to.be.undefined;
-      expect(result.data?.getScheduledCuratedCorpusItems).to.have.lengthOf(0);
+      expect(result.errors).not.to.be.null;
+
+      // typescript needs this check bc result.errors _could_ be empty
+      // (we check above to ensure it is not)
+      if (result.errors) {
+        expect(result.errors.length).to.equal(1);
+        expect(result.errors[0].message).to.equal(
+          'not-a-valid-id-by-any-means is not a valid Scheduled Surface GUID'
+        );
+      }
+    });
+
+    it('should fail on non-existent Scheduled Surface GUID', async () => {
+      const result = await server.executeOperation({
+        query: GET_SCHEDULED_ITEMS,
+        variables: {
+          filters: {
+            // can't believe graphql lets you pass an empty string for a required parameter
+            scheduledSurfaceGuid: '',
+            startDate: '2000-01-01',
+            endDate: '2050-12-31',
+          },
+        },
+      });
+
+      expect(result.errors).not.to.be.null;
+
+      // typescript needs this check bc result.errors _could_ be empty
+      // (we check above to ensure it is not)
+      if (result.errors) {
+        expect(result.errors.length).to.equal(1);
+        expect(result.errors[0].message).to.equal(
+          ' is not a valid Scheduled Surface GUID'
+        );
+      }
     });
   });
 });

--- a/src/database/queries/ScheduledItem.ts
+++ b/src/database/queries/ScheduledItem.ts
@@ -6,6 +6,7 @@ import {
   ScheduledItemsResult,
   ScheduledSurfaceItem,
 } from '../types';
+import { scheduledSurfaceAllowedValues } from '../../shared/types';
 import { groupBy } from '../../shared/utils';
 
 /**
@@ -17,6 +18,13 @@ export async function getScheduledItems(
   filters: ScheduledItemFilterInput
 ): Promise<ScheduledItemsResult[]> {
   const { scheduledSurfaceGuid, startDate, endDate } = filters;
+
+  // validate scheduledSurfaceGuid
+  if (!scheduledSurfaceAllowedValues.includes(scheduledSurfaceGuid)) {
+    throw new Error(
+      `${scheduledSurfaceGuid} is not a valid Scheduled Surface GUID`
+    );
+  }
 
   // Get a flat array of scheduled items from Prisma
   const items = await db.scheduledItem.findMany({

--- a/src/public/resolvers/queries/ScheduledSurface.integration.ts
+++ b/src/public/resolvers/queries/ScheduledSurface.integration.ts
@@ -35,11 +35,9 @@ describe('queries: ScheduledSurface', () => {
     // There should be errors
     expect(result.errors).not.to.be.null;
 
-    if (result.errors) {
-      expect(result.errors[0].message).to.contain(
-        `Could not find Scheduled Surface with id of "ABRACADABRA"`
-      );
-      expect(result.errors[0].extensions?.code).to.equal('BAD_USER_INPUT');
-    }
+    expect(result.errors?.[0].message).to.contain(
+      `Could not find Scheduled Surface with id of "ABRACADABRA"`
+    );
+    expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
   });
 });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -87,6 +87,16 @@ export enum MozillaAccessGroup {
   POCKET_HITS_CURATOR_DEDE = 'mozilliansorg_pocket_pocket_hits_curator_dede', // Access to de de Pocket Hits in the corpus tool.
 }
 
+// enum that maps the scheduled surface guid to a Mozilla access group
+export enum ScheduledSurfaceGuidToMozillaAccessGroup {
+  NEW_TAB_EN_US = MozillaAccessGroup.NEW_TAB_CURATOR_ENUS,
+  NEW_TAB_EN_GB = MozillaAccessGroup.NEW_TAB_CURATOR_ENGB,
+  NEW_TAB_EN_INTL = MozillaAccessGroup.NEW_TAB_CURATOR_ENINTL,
+  NEW_TAB_DE_DE = MozillaAccessGroup.NEW_TAB_CURATOR_DEDE,
+  POCKET_HITS_EN_US = MozillaAccessGroup.POCKET_HITS_CURATOR_ENUS,
+  POCKET_HITS_DE_DE = MozillaAccessGroup.POCKET_HITS_CURATOR_DEDE,
+}
+
 export const AccessGroupToScheduledSurfaceMap: {
   [key in MozillaAccessGroup]?: ScheduledSurface;
 } = {
@@ -127,3 +137,6 @@ export enum Topics {
   TECHNOLOGY = 'TECHNOLOGY',
   TRAVEL = 'TRAVEL',
 }
+
+export const ACCESS_DENIED_ERROR =
+  'You do not have access to perform this action.';

--- a/src/test/helpers/getServerWithMockedHeaders.ts
+++ b/src/test/helpers/getServerWithMockedHeaders.ts
@@ -4,13 +4,10 @@ import { ContextManager } from '../../admin/context';
 import { client } from '../../database/client';
 import s3 from '../../admin/aws/s3';
 
-const eventEmitter = new CuratedCorpusEventEmitter();
-
 const sharedConfigContext = {
   request: { headers: {} },
   db: client(),
   s3,
-  eventEmitter,
 };
 
 /**
@@ -18,14 +15,19 @@ const sharedConfigContext = {
  * within resolvers.
  *
  * @param headers
+ * @param eventEmitter
  */
-export const getServerWithMockedHeaders = (headers: {
-  name: string;
-  username: string;
-  groups: string;
-}) => {
+export const getServerWithMockedHeaders = (
+  headers: {
+    name: string;
+    username: string;
+    groups: string;
+  },
+  eventEmitter: CuratedCorpusEventEmitter = new CuratedCorpusEventEmitter()
+) => {
   const contextManager = new ContextManager({
     ...sharedConfigContext,
+    eventEmitter,
     request: {
       headers,
     },


### PR DESCRIPTION
## Goal

- Improved auth user context with more convenience props (heavily inspired by the approach taken in Prospect API).

- Added access control checks to `createScheduledItem` and `deleteScheduledItem` mutations.

- Updated existing tests. Added new integration tests that test various user privilege scenarios.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1173
