### PR TITLE
chore(shared data): update prospect types & new tab de_de

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -73,6 +73,7 @@ enum ProspectType {
     ORGANIC_TIMESPENT
     SYNDICATED
     TOP_SAVED
+    DOMAIN_ALLOWLIST
 }
 
 """

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4,6 +4,7 @@ export enum ProspectType {
   ORGANIC_TIMESPENT = 'ORGANIC_TIMESPENT',
   SYNDICATED = 'SYNDICATED',
   TOP_SAVED = 'TOP_SAVED',
+  DOMAIN_ALLOWLIST = 'DOMAIN_ALLOWLIST',
 }
 
 export type ScheduledSurface = {
@@ -32,7 +33,11 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
     name: 'New Tab (de-DE)',
     guid: 'NEW_TAB_DE_DE',
     utcOffset: 100,
-    prospectTypes: [ProspectType.GLOBAL, ProspectType.ORGANIC_TIMESPENT],
+    prospectTypes: [
+      ProspectType.GLOBAL,
+      ProspectType.ORGANIC_TIMESPENT,
+      ProspectType.DOMAIN_ALLOWLIST,
+    ],
   },
   {
     name: 'New Tab (en-GB)',


### PR DESCRIPTION
## Goal

updating shared data based on matt cooper's latest ML work.

- add `DOMAIN_ALLOWLIST` as a `ProspectType`
- associate `DOMAIN_ALLOWLIST` with `NEW_TAB_DE_DE` scheduled surface

## References

Slack:
* https://pocket.slack.com/archives/CTLKW5WCF/p1644938746449939