### PR TITLE
chore(snowplow): update schema to use scheduled surface

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -59,7 +59,7 @@ export default {
       reviewedCorpusItem:
         'iglu:com.pocket/reviewed_corpus_item/jsonschema/1-0-1',
       scheduledCorpusItem:
-        'iglu:com.pocket/scheduled_corpus_item/jsonschema/1-0-0',
+        'iglu:com.pocket/scheduled_corpus_item/jsonschema/1-0-1',
     },
   },
 };

--- a/src/events/snowplow/ScheduledItemSnowplowHandler.integration.ts
+++ b/src/events/snowplow/ScheduledItemSnowplowHandler.integration.ts
@@ -75,11 +75,11 @@ function assertValidSnowplowScheduledItemEvents(data) {
         url: scheduledCorpusItem.approvedItem.url,
 
         scheduled_at: getUnixTimestamp(scheduledCorpusItem.scheduledDate),
-        new_tab_id: scheduledCorpusItem.scheduledSurfaceGuid,
-        new_tab_name: getScheduledSurfaceByGuid(
+        scheduled_surface_id: scheduledCorpusItem.scheduledSurfaceGuid,
+        scheduled_surface_name: getScheduledSurfaceByGuid(
           scheduledCorpusItem.scheduledSurfaceGuid
         )?.name,
-        new_tab_feed_utc_offset: getScheduledSurfaceByGuid(
+        scheduled_surface_utc_offset: getScheduledSurfaceByGuid(
           scheduledCorpusItem.scheduledSurfaceGuid
         )?.utcOffset.toString(),
         created_at: getUnixTimestamp(scheduledCorpusItem.createdAt),

--- a/src/events/snowplow/ScheduledItemSnowplowHandler.ts
+++ b/src/events/snowplow/ScheduledItemSnowplowHandler.ts
@@ -85,7 +85,7 @@ export class ScheduledItemSnowplowHandler extends CuratedCorpusSnowplowHandler {
         scheduled_at: getUnixTimestamp(item.scheduledDate),
         url: item.approvedItem.url,
         approved_corpus_item_external_id: item.approvedItem.externalId,
-        new_tab_id: item.scheduledSurfaceGuid,
+        scheduled_surface_id: item.scheduledSurfaceGuid,
         created_at: getUnixTimestamp(item.createdAt),
         created_by: item.createdBy,
         updated_at: getUnixTimestamp(item.updatedAt),
@@ -101,8 +101,8 @@ export class ScheduledItemSnowplowHandler extends CuratedCorpusSnowplowHandler {
     if (scheduledSurface) {
       context.data = {
         ...context.data,
-        new_tab_name: scheduledSurface.name,
-        new_tab_feed_utc_offset: scheduledSurface.utcOffset.toString(),
+        scheduled_surface_name: scheduledSurface.name,
+        scheduled_surface_utc_offset: scheduledSurface.utcOffset.toString(),
       };
     }
 

--- a/src/events/snowplow/schema.ts
+++ b/src/events/snowplow/schema.ts
@@ -158,15 +158,15 @@ export type ScheduledCorpusItem = {
   /**
    * A guid that identifies the scheduled surface, e.g. 'NEW_TAB_EN_US'.
    */
-  new_tab_id: string;
+  scheduled_surface_id: string;
   /**
    * The name of the scheduled surface.
    */
-  new_tab_name?: string;
+  scheduled_surface_name?: string;
   /**
    * The time that the scheduled surface feed is offset from UTC time.
    */
-  new_tab_feed_utc_offset?: string;
+  scheduled_surface_utc_offset?: string;
   /**
    * The UTC unix timestamp (in seconds) for when the scheduled surface schedule
    * was created.


### PR DESCRIPTION
## Goal

update snowplow schema to use `scheduled_surface` instead of `new_tab`.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1318

Slack thread:
* https://pocket.slack.com/archives/CTLKW5WCF/p1644956989056359