### PR TITLE
feat(auth): Add access checks around creating a corpus item [BACK-1325]

### DIFF
--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -71,7 +71,7 @@ describe('mutations: ApprovedItem', () => {
       isSyndicated: false,
     };
 
-    it('creates an approved item with all inputs supplied', async () => {
+    it('should create an approved item if user has full access', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
       eventEmitter.on(ReviewedCorpusItemEventType.ADD_ITEM, eventTracker);
@@ -103,7 +103,7 @@ describe('mutations: ApprovedItem', () => {
       ).to.equal(result.data?.createApprovedCuratedCorpusItem.externalId);
     });
 
-    it('creates an approved item without a prospectId', async () => {
+    it('should create an approved item without a prospectId', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
       eventEmitter.on(ReviewedCorpusItemEventType.ADD_ITEM, eventTracker);
@@ -601,6 +601,139 @@ describe('mutations: ApprovedItem', () => {
       expect(data?.uploadApprovedCuratedCorpusItemImage.url).to.match(
         urlPattern
       );
+    });
+  });
+});
+
+describe('mutations: ApprovedItem - authentication checks', () => {
+  const eventEmitter = new CuratedCorpusEventEmitter();
+
+  // a standard set of inputs for this mutation
+  const input: CreateApprovedItemInput = {
+    prospectId: '123-abc',
+    title: 'Find Out How I Cured My Docker In 2 Days',
+    url: 'https://test.com/docker',
+    excerpt: 'A short summary of what this story is about',
+    status: CuratedStatus.CORPUS,
+    imageUrl: 'https://test.com/image.png',
+    language: 'de',
+    publisher: 'Convective Cloud',
+    topic: 'Technology',
+    isCollection: false,
+    isTimeSensitive: true,
+    isSyndicated: false,
+  };
+
+  describe('createApprovedCuratedCorpusItem mutation', () => {
+    it('should succeed if user has access to one of scheduled surfaces', async () => {
+      // set up event tracking
+      const eventTracker = sinon.fake();
+      eventEmitter.on(ReviewedCorpusItemEventType.ADD_ITEM, eventTracker);
+
+      // Set up auth headers with access to a single Scheduled Surface
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_ENGB}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers, eventEmitter);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: CREATE_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.errors).to.be.undefined;
+      expect(result.data).not.to.be.null;
+
+      // Expect to see all the input data we supplied in the Approved Item
+      // returned by the mutation
+      expect(result.data?.createApprovedCuratedCorpusItem).to.deep.include(
+        input
+      );
+
+      // Check that the ADD_ITEM event was fired successfully:
+      // 1 - Event was fired once!
+      expect(eventTracker.callCount).to.equal(1);
+      // 2 - Event has the right type.
+      expect(await eventTracker.getCall(0).args[0].eventType).to.equal(
+        ReviewedCorpusItemEventType.ADD_ITEM
+      );
+      // 3- Event has the right entity passed to it.
+      expect(
+        await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
+      ).to.equal(result.data?.createApprovedCuratedCorpusItem.externalId);
+
+      await server.stop();
+    });
+
+    it('should fail if request headers are not supplied', async () => {
+      // With the default context, the headers are empty
+      const server = getServer(eventEmitter);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: CREATE_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.null;
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+
+    it("should fail if user doesn't have access to any of scheduled surfaces", async () => {
+      // Set up auth headers with access to something irrelevant here, such as collections
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.COLLECTION_CURATOR_FULL}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers, eventEmitter);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: CREATE_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.null;
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+
+    it('should fail optional scheduling if user has no access to relevant scheduled surface', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_DEDE}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers, eventEmitter);
+      await server.start();
+
+      // extra inputs for scheduling - note attempting to schedule onto the US New Tab
+      // while only having access to the German New Tab
+      input.scheduledDate = '2100-01-01';
+      input.scheduledSurfaceGuid = 'NEW_TAB_EN_US';
+
+      const result = await server.executeOperation({
+        query: CREATE_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.null;
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
     });
   });
 });

--- a/src/admin/resolvers/mutations/ApprovedItem.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.ts
@@ -36,6 +36,20 @@ export async function createApprovedItem(
 ): Promise<ApprovedItem> {
   const { scheduledDate, scheduledSurfaceGuid, ...approvedItemData } = data;
 
+  // If this item is being created and scheduled at the same time,
+  // the user needs write access to the relevant scheduled surface.
+  if (
+    scheduledSurfaceGuid &&
+    !context.authenticatedUser.canWriteToSurface(scheduledSurfaceGuid)
+  ) {
+    throw new AuthenticationError(ACCESS_DENIED_ERROR);
+  }
+
+  // If there is no optional scheduling, check if the user can write to the corpus.
+  if (!context.authenticatedUser.canWriteToCorpus()) {
+    throw new AuthenticationError(ACCESS_DENIED_ERROR);
+  }
+
   if (
     scheduledDate &&
     scheduledSurfaceGuid &&


### PR DESCRIPTION
## Goal

- [x] Add an access check to creating a corpus item (done, anyone who has write access can do that).
- [x] Add integration tests for the above
- [x] Get one bizarre test failure to go away (?!!) - fixed by splitting auth-related tests into their own `describe()` block.
- [x] Add an extra access check in the same mutation for the optional scheduling - the solution we arrived to while pairing with @jpetto is to check for `canWriteToSurface` access if scheduling is specified and to check for `canWriteToCorpus` if item is only being added to the corpus.
- [x] Add more integration tests


## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1325