### PR TITLE
feat(auth): Add auth check to `uploadApprovedItemImage` mutation [BACK-1346]

### DIFF
--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -738,7 +738,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
   });
 
   describe('rejectApprovedItem mutation', () => {
-    it('should successfully reject an approved item when the user has access to at least one scheduled surface ', async () => {
+    it('should successfully reject an approved item when the user has access to at least one scheduled surface', async () => {
       // Set up auth headers with access to a single Scheduled Surface
       const headers = {
         name: 'Test User',
@@ -777,7 +777,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       await server.stop();
     });
 
-    it('should throw an error when the user has no access any scheduled surface ', async () => {
+    it('should throw an error when the user has no access any scheduled surface', async () => {
       // Set up auth headers without access to any Scheduled Surface
       const headers = {
         name: 'Test User',
@@ -806,7 +806,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       await server.stop();
     });
 
-    it('should throw an error when the user has only read-only access ', async () => {
+    it('should throw an error when the user has only read-only access', async () => {
       // Set up auth headers with read-only access
       const headers = {
         name: 'Test User',
@@ -835,7 +835,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       await server.stop();
     });
 
-    it('should throw an error when the request headers are undefined  ', async () => {
+    it('should throw an error when the request headers are undefined', async () => {
       // pass in empty object for headers
       const server = getServerWithMockedHeaders({});
       await server.start();
@@ -853,6 +853,51 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.errors).not.to.be.undefined;
       expect(result.data).to.be.null;
 
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+  });
+
+  describe('uploadApprovedCuratedCorpusItemImage mutation', () => {
+    const testFilePath = __dirname + '/test-image.jpeg';
+
+    beforeEach(() => {
+      writeFileSync(testFilePath, 'I am an image');
+    });
+
+    afterEach(() => {
+      unlinkSync(testFilePath);
+    });
+
+    it('should not succeed if user does not have write to corpus privileges', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.READONLY}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+      await server.start();
+
+      const image: Upload = new Upload();
+
+      image.resolve({
+        filename: 'test.jpg',
+        mimetype: 'image/jpeg',
+        encoding: '7bit',
+        createReadStream: () => createReadStream(testFilePath),
+      });
+
+      const result = await server.executeOperation({
+        query: UPLOAD_APPROVED_ITEM_IMAGE,
+        variables: {
+          image: image,
+        },
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.null;
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
 
       await server.stop();

--- a/src/admin/resolvers/mutations/ApprovedItem.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.ts
@@ -180,13 +180,19 @@ export async function rejectApprovedItem(
  *
  * @param parent
  * @param data
+ * @param context
  * @param s3
  */
 export async function uploadApprovedItemImage(
   parent,
   { data },
-  { s3 }
+  context: IContext
 ): Promise<ApprovedItemS3ImageUrl> {
+  // check if user is is allowed to upload images
+  if (!context.authenticatedUser.canWriteToCorpus()) {
+    throw new AuthenticationError(ACCESS_DENIED_ERROR);
+  }
+
   const image = await data;
-  return await uploadImageToS3(s3, image);
+  return await uploadImageToS3(context.s3, image);
 }


### PR DESCRIPTION
## Goal

This is fairly straightforward. As long as the user has write access to the corpus, they should be able to upload images to S3. 

- Added an authentication check to the mutation.

- Added an integration test.

## References

JIRA ticket: https://getpocket.atlassian.net/browse/BACK-1346