### PR TITLE
fix(validation): validate topic and rejection reason enums on mutations

### DIFF
--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -143,5 +143,14 @@ export enum Topics {
   TRAVEL = 'TRAVEL',
 }
 
+export enum RejectionReason {
+  PAYWALL = 'PAYWALL',
+  POLITICAL_OPINION = 'POLITICAL_OPINION',
+  OFFENSIVE_MATERIAL = 'OFFENSIVE_MATERIAL',
+  TIME_SENSITIVE = 'TIME_SENSITIVE',
+  MISINFORMATION = 'MISINFORMATION',
+  OTHER = 'OTHER',
+}
+
 export const ACCESS_DENIED_ERROR =
   'You do not have access to perform this action.';


### PR DESCRIPTION
## Goal

prevent invalid `Topic` and `RejectionReason` values from making it into the db.

## I'd love feedback/perspectives on:
- not-very-DRY code. should these checks go into a helper?

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1351