### PR TITLE
feat(auth): [BACK-1343] Add auth to `getRejectedCuratedCorpusItems` query

### DIFF
--- a/src/admin/resolvers/queries/RejectedItem.auth.integration.ts
+++ b/src/admin/resolvers/queries/RejectedItem.auth.integration.ts
@@ -1,0 +1,145 @@
+import { db } from '../../../test/admin-server';
+import {
+  clearDb,
+  createRejectedCuratedCorpusItemHelper,
+  getServerWithMockedHeaders,
+} from '../../../test/helpers';
+import { ACCESS_DENIED_ERROR, MozillaAccessGroup } from '../../../shared/types';
+import { GET_REJECTED_ITEMS } from './sample-queries.gql';
+import { expect } from 'chai';
+
+describe('queries: RejectedCuratedCorpusItem (authentication)', () => {
+  // A few sample Rejected Curated Corpus items - we don't need a lot of these
+  // for auth checks
+  const rejectedCuratedCorpusItems = [
+    {
+      title: '10 Unforgivable Sins Of PHP',
+    },
+    {
+      title: 'Take The Stress Out Of PHP',
+    },
+    {
+      title: 'The Untold Secret To Mastering PHP In Just 3 Days',
+    },
+    {
+      title: 'You Can Thank Us Later - 3 Reasons To Stop Thinking About PHP',
+    },
+  ];
+
+  let headers: {
+    name: string | undefined;
+    username: string | undefined;
+    groups: string | undefined;
+  } = {
+    name: 'Test User',
+    username: 'test.user@test.com',
+    groups: undefined,
+  };
+
+  beforeAll(async () => {
+    await clearDb(db);
+
+    for (const item of rejectedCuratedCorpusItems) {
+      await createRejectedCuratedCorpusItemHelper(db, item);
+    }
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  describe('getRejectedCuratedCorpusItem query', () => {
+    it('should get all items when user has read-only access', async () => {
+      // Set up auth headers with read-only access
+      headers = {
+        ...headers,
+        groups: `this,that,${MozillaAccessGroup.READONLY}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: GET_REJECTED_ITEMS,
+      });
+
+      expect(result.errors).to.be.undefined;
+      expect(result.data).not.to.be.null;
+
+      // should return all four items - the entire corpus should be accessible
+      expect(result.data?.getRejectedCuratedCorpusItems.edges).to.have.length(
+        4
+      );
+
+      await server.stop();
+    });
+
+    it('should get all items when user has only one scheduled surface access', async () => {
+      // Set up auth headers with access to a single Scheduled Surface
+      headers = {
+        ...headers,
+        groups: `this,that,${MozillaAccessGroup.NEW_TAB_CURATOR_ENUS}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: GET_REJECTED_ITEMS,
+      });
+
+      expect(result.errors).to.be.undefined;
+      expect(result.data).not.to.be.null;
+
+      // should return all four items - the entire corpus should be accessible
+      expect(result.data?.getRejectedCuratedCorpusItems.edges).to.have.length(
+        4
+      );
+
+      await server.stop();
+    });
+
+    it('should throw an error when user does not have the required access', async () => {
+      // Set up auth headers with no valid access group
+      headers = {
+        ...headers,
+        groups: `this,that`,
+      };
+      const server = getServerWithMockedHeaders(headers);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: GET_REJECTED_ITEMS,
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.undefined;
+
+      // check if the error we get is the access denied error
+      expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
+
+      await server.stop();
+    });
+
+    it('should throw an error when request access groups are undefined', async () => {
+      // Set up auth headers with no access groups whatsoever (the default
+      // on top of the `describe()` block for Rejected Item queries).
+      const server = getServerWithMockedHeaders(headers);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: GET_REJECTED_ITEMS,
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.undefined;
+
+      // check if the error we get is the access denied error
+      expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
+
+      await server.stop();
+    });
+  });
+});

--- a/src/admin/resolvers/queries/RejectedItem.integration.ts
+++ b/src/admin/resolvers/queries/RejectedItem.integration.ts
@@ -1,15 +1,26 @@
 import { expect } from 'chai';
 import { RejectedCuratedCorpusItem as dbRejectedCuratedCorpusItem } from '@prisma/client';
-import { db, getServer } from '../../../test/admin-server';
+import { db } from '../../../test/admin-server';
 import {
   clearDb,
   createRejectedCuratedCorpusItemHelper,
 } from '../../../test/helpers';
 import { GET_REJECTED_ITEMS } from './sample-queries.gql';
 import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
+import { MozillaAccessGroup } from '../../../shared/types';
+import { getServerWithMockedHeaders } from '../../../test/helpers/getServerWithMockedHeaders';
 
 describe('queries: RejectedCuratedCorpusItem', () => {
-  const server = getServer(new CuratedCorpusEventEmitter());
+  const headers = {
+    name: 'Test User',
+    username: 'test.user@test.com',
+    groups: `group1,group2,${MozillaAccessGroup.READONLY}`,
+  };
+
+  const server = getServerWithMockedHeaders(
+    headers,
+    new CuratedCorpusEventEmitter()
+  );
 
   beforeAll(async () => {
     await clearDb(db);


### PR DESCRIPTION
## Goal

- Added authentication checks to `getRejectedCuratedCorpusItems` query.

- Added auth-related integration tests.

- Added mock headers to existing tests for Rejected Item queries so that they keep passing after the change.


## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1343
