### PR TITLE
feat(auth): [BACK-1344] add auth to `getScheduledCuratedCorpusItems` query

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "npm test -- --watchAll",
     "test": "jest \"\\.spec\\.ts\"",
     "test-setup": "export $(egrep -v '^#' .docker/local.env | xargs -0) && ./.circleci/scripts/setup.sh --hosts",
-    "test-integrations": "jest \"ScheduledItem\\.auth\\.integration\\.ts\" --runInBand",
+    "test-integrations": "jest \"\\.integration\\.ts\" --runInBand",
     "test-integrations:watch": "npm run test-integrations -- --watchAll",
     "lint-check": "eslint --fix-dry-run \"src/**/*.ts\"",
     "lint-fix": "eslint --fix \"src/**/*.ts\"",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "npm test -- --watchAll",
     "test": "jest \"\\.spec\\.ts\"",
     "test-setup": "export $(egrep -v '^#' .docker/local.env | xargs -0) && ./.circleci/scripts/setup.sh --hosts",
-    "test-integrations": "jest \"\\.integration\\.ts\" --runInBand",
+    "test-integrations": "jest \"ScheduledItem\\.auth\\.integration\\.ts\" --runInBand",
     "test-integrations:watch": "npm run test-integrations -- --watchAll",
     "lint-check": "eslint --fix-dry-run \"src/**/*.ts\"",
     "lint-fix": "eslint --fix \"src/**/*.ts\"",

--- a/src/admin/resolvers/queries/ScheduledItem.auth.integration.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.auth.integration.ts
@@ -52,10 +52,7 @@ describe('queries: ScheduledCuratedCorpusItem - authentication', () => {
         groups: `group1,group2,${MozillaAccessGroup.READONLY}`,
       };
 
-      const server = getServerWithMockedHeaders(
-        headers,
-        new CuratedCorpusEventEmitter()
-      );
+      const server = getServerWithMockedHeaders(headers);
 
       const result = await server.executeOperation({
         query: GET_SCHEDULED_ITEMS,
@@ -85,10 +82,7 @@ describe('queries: ScheduledCuratedCorpusItem - authentication', () => {
         groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_DEDE}`,
       };
 
-      const server = getServerWithMockedHeaders(
-        headers,
-        new CuratedCorpusEventEmitter()
-      );
+      const server = getServerWithMockedHeaders(headers);
 
       // even though user has access for DE_DE only, a request for EN_US should work
       const result = await server.executeOperation({
@@ -120,7 +114,6 @@ describe('queries: ScheduledCuratedCorpusItem - authentication', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_SCHEDULED_ITEMS,
@@ -139,8 +132,6 @@ describe('queries: ScheduledCuratedCorpusItem - authentication', () => {
       // check if the error we get is access denied error
       expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
       expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
-
-      await server.stop();
     });
 
     it('should throw an error when request header groups are undefined', async () => {
@@ -152,7 +143,6 @@ describe('queries: ScheduledCuratedCorpusItem - authentication', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_SCHEDULED_ITEMS,
@@ -171,8 +161,6 @@ describe('queries: ScheduledCuratedCorpusItem - authentication', () => {
       // check if the error we get is access denied error
       expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
       expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
-
-      await server.stop();
     });
   });
 });

--- a/src/admin/resolvers/queries/ScheduledItem.auth.integration.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.auth.integration.ts
@@ -1,0 +1,178 @@
+import { expect } from 'chai';
+import {
+  clearDb,
+  createApprovedItemHelper,
+  createScheduledItemHelper,
+  getServerWithMockedHeaders,
+} from '../../../test/helpers';
+import { db } from '../../../test/admin-server';
+import { GET_SCHEDULED_ITEMS } from './sample-queries.gql';
+import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
+import { ACCESS_DENIED_ERROR, MozillaAccessGroup } from '../../../shared/types';
+
+describe('queries: ScheduledCuratedCorpusItem - authentication', () => {
+  beforeAll(async () => {
+    await clearDb(db);
+
+    // Create some approved items and schedule them for a date in the future
+    for (let i = 0; i < 5; i++) {
+      const approvedItem = await createApprovedItemHelper(db, {
+        title: `Batch 1, Story #${i + 1}`,
+      });
+      await createScheduledItemHelper(db, {
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+        approvedItem,
+        scheduledDate: new Date('2050-01-01').toISOString(),
+      });
+    }
+
+    // Create more approved items for a different scheduled date
+    for (let i = 0; i < 10; i++) {
+      const approvedItem = await createApprovedItemHelper(db, {
+        title: `Batch 2, Story #${i + 1}`,
+      });
+      await createScheduledItemHelper(db, {
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+        approvedItem,
+        scheduledDate: new Date('2025-05-05').toISOString(),
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  describe('getScheduledCuratedCorpusItems query', () => {
+    it('should get all items when the user has read-only access', async () => {
+      // adding headers with groups with read-only access
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.READONLY}`,
+      };
+
+      const server = getServerWithMockedHeaders(
+        headers,
+        new CuratedCorpusEventEmitter()
+      );
+
+      const result = await server.executeOperation({
+        query: GET_SCHEDULED_ITEMS,
+        variables: {
+          filters: {
+            scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+            startDate: '2000-01-01',
+            endDate: '2050-12-31',
+          },
+        },
+      });
+
+      expect(result.errors).to.be.undefined;
+      expect(result.data).not.to.be.null;
+
+      const resultArray = result.data?.getScheduledCuratedCorpusItems;
+      expect(resultArray).to.have.lengthOf(2);
+      expect(resultArray[0].totalCount).to.equal(10);
+      expect(resultArray[0].items).to.have.lengthOf(10);
+    });
+
+    it('should get all items when user the has only one scheduled surface access', async () => {
+      // adding headers with groups with DE_DE surface access only
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_DEDE}`,
+      };
+
+      const server = getServerWithMockedHeaders(
+        headers,
+        new CuratedCorpusEventEmitter()
+      );
+
+      // even though user has access for DE_DE only, a request for EN_US should work
+      const result = await server.executeOperation({
+        query: GET_SCHEDULED_ITEMS,
+        variables: {
+          filters: {
+            scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+            startDate: '2000-01-01',
+            endDate: '2050-12-31',
+          },
+        },
+      });
+
+      expect(result.errors).to.be.undefined;
+      expect(result.data).not.to.be.null;
+
+      const resultArray = result.data?.getScheduledCuratedCorpusItems;
+      expect(resultArray).to.have.lengthOf(2);
+      expect(resultArray[0].totalCount).to.equal(10);
+      expect(resultArray[0].items).to.have.lengthOf(10);
+    });
+
+    it('should throw an error when user does not have the required access', async () => {
+      // Set up auth headers with no valid access group
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: GET_SCHEDULED_ITEMS,
+        variables: {
+          filters: {
+            scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+            startDate: '2000-01-01',
+            endDate: '2050-12-31',
+          },
+        },
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.undefined;
+
+      // check if the error we get is access denied error
+      expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
+
+      await server.stop();
+    });
+
+    it('should throw an error when request header groups are undefined', async () => {
+      // Set up auth headers with no valid access group
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: undefined,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: GET_SCHEDULED_ITEMS,
+        variables: {
+          filters: {
+            scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+            startDate: '2000-01-01',
+            endDate: '2050-12-31',
+          },
+        },
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.undefined;
+
+      // check if the error we get is access denied error
+      expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
+
+      await server.stop();
+    });
+  });
+});

--- a/src/admin/resolvers/queries/ScheduledItem.auth.integration.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.auth.integration.ts
@@ -7,7 +7,6 @@ import {
 } from '../../../test/helpers';
 import { db } from '../../../test/admin-server';
 import { GET_SCHEDULED_ITEMS } from './sample-queries.gql';
-import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
 import { ACCESS_DENIED_ERROR, MozillaAccessGroup } from '../../../shared/types';
 
 describe('queries: ScheduledCuratedCorpusItem - authentication', () => {

--- a/src/admin/resolvers/queries/ScheduledItem.integration.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.integration.ts
@@ -3,13 +3,25 @@ import {
   clearDb,
   createApprovedItemHelper,
   createScheduledItemHelper,
+  getServerWithMockedHeaders,
 } from '../../../test/helpers';
-import { db, getServer } from '../../../test/admin-server';
+import { db } from '../../../test/admin-server';
 import { GET_SCHEDULED_ITEMS } from './sample-queries.gql';
 import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
+import { MozillaAccessGroup } from '../../../shared/types';
 
 describe('queries: ScheduledCuratedCorpusItem', () => {
-  const server = getServer(new CuratedCorpusEventEmitter());
+  // adding headers with groups that grant full access
+  const headers = {
+    name: 'Test User',
+    username: 'test.user@test.com',
+    groups: `group1,group2,${MozillaAccessGroup.SCHEDULED_SURFACE_CURATOR_FULL}`,
+  };
+
+  const server = getServerWithMockedHeaders(
+    headers,
+    new CuratedCorpusEventEmitter()
+  );
 
   beforeAll(async () => {
     await clearDb(db);

--- a/src/admin/resolvers/queries/ScheduledItem.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.ts
@@ -1,5 +1,8 @@
+import { AuthenticationError } from 'apollo-server-core';
 import { getScheduledItems as dbGetScheduledItems } from '../../../database/queries';
 import { ScheduledItemsResult } from '../../../database/types';
+import { ACCESS_DENIED_ERROR } from '../../../shared/types';
+import { IContext } from '../../context';
 
 /**
  * Retrieves a list of Approved Items that are scheduled to appear on a Scheduled Surface
@@ -8,7 +11,15 @@ import { ScheduledItemsResult } from '../../../database/types';
 export async function getScheduledItems(
   parent,
   { filters },
-  { db }
+  context: IContext
 ): Promise<ScheduledItemsResult[]> {
-  return await dbGetScheduledItems(db, filters);
+  //check if the user does not have the permissions to access this query
+  if (
+    !context.authenticatedUser.hasReadOnly &&
+    !context.authenticatedUser.canWriteToCorpus()
+  ) {
+    throw new AuthenticationError(ACCESS_DENIED_ERROR);
+  }
+
+  return await dbGetScheduledItems(context.db, filters);
 }


### PR DESCRIPTION
## Goal
Added auth check to `getScheduledCuratedCorpusItems` query. 
Added new tests in the separate `auth.integration` test file. 
Updated current tests

JIRA ticket:
* [BACK-1344]

[BACK-1344]: https://getpocket.atlassian.net/browse/BACK-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ