### PR TITLE
feat(mutation): add mutation for rescheduling a scheduled item

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -599,6 +599,20 @@ input CreateScheduledCuratedCorpusItemInput {
 }
 
 """
+Input data for rescheduling a scheduled item for a Scheduled Surface.
+"""
+input RescheduleScheduledCuratedCorpusItemInput {
+    """
+    ID of the scheduled item. A string in UUID format.
+    """
+    externalId: ID!
+    """
+    The new scheduled date for the scheduled item to appear on a Scheduled Surface. Format: YYYY-MM-DD.
+    """
+    scheduledDate: Date!
+}
+
+"""
 Input data for deleting a scheduled item for a Scheduled Surface.
 """
 input DeleteScheduledCuratedCorpusItemInput {
@@ -693,6 +707,13 @@ type Mutation {
     """
     deleteScheduledCuratedCorpusItem(
         data: DeleteScheduledCuratedCorpusItemInput!
+    ): ScheduledCuratedCorpusItem!
+
+    """
+    Updates the scheduled date of a Scheduled Surface Scheduled Item.
+    """
+    rescheduleScheduledCuratedCorpusItem(
+        data: RescheduleScheduledCuratedCorpusItemInput!
     ): ScheduledCuratedCorpusItem!
 
     """

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -14,6 +14,7 @@ import { createRejectedItem } from './mutations/RejectedItem';
 import {
   createScheduledItem,
   deleteScheduledItem,
+  rescheduleScheduledItem,
 } from './mutations/ScheduledItem';
 import { GraphQLUpload } from 'graphql-upload';
 
@@ -51,6 +52,7 @@ export const resolvers = {
     createRejectedCuratedCorpusItem: createRejectedItem,
     createScheduledCuratedCorpusItem: createScheduledItem,
     deleteScheduledCuratedCorpusItem: deleteScheduledItem,
+    rescheduleScheduledCuratedCorpusItem: rescheduleScheduledItem,
     uploadApprovedCuratedCorpusItemImage: uploadApprovedItemImage,
   },
 };

--- a/src/admin/resolvers/mutations/ScheduledItem.integration.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.integration.ts
@@ -9,10 +9,12 @@ import {
 import {
   CREATE_SCHEDULED_ITEM,
   DELETE_SCHEDULED_ITEM,
+  RESCHEDULE_SCHEDULED_ITEM,
 } from './sample-mutations.gql';
 import {
   CreateScheduledItemInput,
   DeleteScheduledItemInput,
+  RescheduleScheduledItemInput,
 } from '../../../database/types';
 import { getUnixTimestamp } from '../fields/UnixTimestamp';
 import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
@@ -29,15 +31,11 @@ describe('mutations: ScheduledItem', () => {
     username: 'test.user@test.com',
     groups: `group1,group2,${MozillaAccessGroup.SCHEDULED_SURFACE_CURATOR_FULL}`,
   };
-  const server = getServerWithMockedHeaders(headers, eventEmitter);
 
-  beforeAll(async () => {
-    await server.start();
-  });
+  const server = getServerWithMockedHeaders(headers, eventEmitter);
 
   afterAll(async () => {
     await db.$disconnect();
-    await server.stop();
   });
 
   beforeEach(async () => {
@@ -229,7 +227,6 @@ describe('mutations: ScheduledItem', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const approvedItem = await createApprovedItemHelper(db, {
         title: 'A test story',
@@ -253,8 +250,6 @@ describe('mutations: ScheduledItem', () => {
 
       // And there is an access denied error
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
 
     it("should fail if user doesn't have access to specified scheduled surface", async () => {
@@ -265,7 +260,6 @@ describe('mutations: ScheduledItem', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const approvedItem = await createApprovedItemHelper(db, {
         title: 'A test story',
@@ -289,8 +283,6 @@ describe('mutations: ScheduledItem', () => {
 
       // And there is an access denied error
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
 
     it('should succeed if user has access to specified scheduled surface', async () => {
@@ -301,7 +293,6 @@ describe('mutations: ScheduledItem', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const approvedItem = await createApprovedItemHelper(db, {
         title: 'A test story',
@@ -323,8 +314,6 @@ describe('mutations: ScheduledItem', () => {
 
       // And no errors, too!
       expect(result.errors).to.be.undefined;
-
-      await server.stop();
     });
   });
 
@@ -440,7 +429,6 @@ describe('mutations: ScheduledItem', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const approvedItem = await createApprovedItemHelper(db, {
         title: 'This is a test',
@@ -463,8 +451,6 @@ describe('mutations: ScheduledItem', () => {
 
       // And there is an access denied error
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
 
     it("should fail if user doesn't have access to specified scheduled surface", async () => {
@@ -475,7 +461,6 @@ describe('mutations: ScheduledItem', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const approvedItem = await createApprovedItemHelper(db, {
         title: 'This is a test',
@@ -498,8 +483,6 @@ describe('mutations: ScheduledItem', () => {
 
       // And there is an access denied error
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
 
     it('should succeed if user has access to specified scheduled surface', async () => {
@@ -510,7 +493,6 @@ describe('mutations: ScheduledItem', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const approvedItem = await createApprovedItemHelper(db, {
         title: 'This is a test',
@@ -531,8 +513,277 @@ describe('mutations: ScheduledItem', () => {
 
       // And no errors, too!
       expect(result.errors).to.be.undefined;
+    });
+  });
 
-      await server.stop();
+  describe('rescheduleScheduledCuratedCorpusItem mutation', () => {
+    it('should fail on invalid external ID', async () => {
+      // Set up event tracking
+      const eventTracker = sinon.fake();
+      eventEmitter.on(ScheduledCorpusItemEventType.RESCHEDULE, eventTracker);
+
+      const input: RescheduleScheduledItemInput = {
+        externalId: 'not-a-valid-ID-string',
+        scheduledDate: '2050-05-04',
+      };
+
+      const result = await server.executeOperation({
+        query: RESCHEDULE_SCHEDULED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.data).to.be.null;
+
+      // And there is the correct error from the resolvers
+      expect(result.errors?.[0].message).to.contain(
+        `Item with ID of '${input.externalId}' could not be found.`
+      );
+
+      expect(result.errors?.[0].extensions?.code).to.equal(
+        'INTERNAL_SERVER_ERROR'
+      );
+
+      // Check that the REMOVE_SCHEDULE event was not fired
+      expect(eventTracker.callCount).to.equal(0);
+    });
+
+    it('should reschedule an item scheduled for a Scheduled Surface and return updated data', async () => {
+      // Set up event tracking
+      const eventTracker = sinon.fake();
+      eventEmitter.on(ScheduledCorpusItemEventType.RESCHEDULE, eventTracker);
+
+      const approvedItem = await createApprovedItemHelper(db, {
+        title: 'This is a test',
+      });
+
+      const scheduledItem = await createScheduledItemHelper(db, {
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+        approvedItem,
+        scheduledDate: new Date(2050, 4, 4).toISOString(),
+      });
+
+      const { data } = await server.executeOperation({
+        query: RESCHEDULE_SCHEDULED_ITEM,
+        variables: {
+          data: {
+            externalId: scheduledItem.externalId,
+            scheduledDate: '2050-05-05',
+          },
+        },
+      });
+
+      // The shape of the Prisma objects the above helpers return doesn't quite match
+      // the type we return in GraphQL (for example, IDs stay internal, we attach an
+      // ApprovedItem), so until there is a query to retrieve the scheduled item
+      // of the right shape (if it's ever implemented), laborious property-by-property
+      // comparison is the go.
+      const returnedItem = data?.rescheduleScheduledCuratedCorpusItem;
+      expect(returnedItem.externalId).to.equal(scheduledItem.externalId);
+      expect(returnedItem.createdBy).to.equal(scheduledItem.createdBy);
+      expect(returnedItem.updatedBy).to.equal(headers.username);
+
+      expect(returnedItem.createdAt).to.equal(
+        getUnixTimestamp(scheduledItem.createdAt)
+      );
+
+      expect(returnedItem.updatedAt).to.equal(
+        getUnixTimestamp(scheduledItem.updatedAt)
+      );
+
+      expect(returnedItem.scheduledDate).to.equal('2050-05-05');
+
+      // Finally, let's compare the returned ApprovedItem object to our inputs.
+      // Need to destructure timestamps and compare them separately
+      // as Prisma will convert to ISO string for comparison
+      // and GraphQL server returns Unix timestamps.
+      const { createdAt, updatedAt, ...otherApprovedItemProps } = approvedItem;
+      const {
+        createdAt: createdAtReturned,
+        updatedAt: updatedAtReturned,
+        ...otherReturnedApprovedItemProps
+      } = returnedItem.approvedItem;
+      expect(getUnixTimestamp(createdAt)).to.equal(createdAtReturned);
+      expect(getUnixTimestamp(updatedAt)).to.equal(updatedAtReturned);
+      expect(otherApprovedItemProps).to.deep.include(
+        otherReturnedApprovedItemProps
+      );
+
+      // Check that the RESCHEDULE event was fired successfully:
+      // 1 - Event was fired once!
+      expect(eventTracker.callCount).to.equal(1);
+      // 2 - Event has the right type.
+      expect(await eventTracker.getCall(0).args[0].eventType).to.equal(
+        ScheduledCorpusItemEventType.RESCHEDULE
+      );
+      // 3- Event has the right entity passed to it.
+      expect(
+        await eventTracker.getCall(0).args[0].scheduledCorpusItem.externalId
+      ).to.equal(scheduledItem.externalId);
+    });
+
+    it('should fail if story is already scheduled for given Scheduled Surface/date combination', async () => {
+      // Set up event tracking
+      const eventTracker = sinon.fake();
+      eventEmitter.on(ScheduledCorpusItemEventType.RESCHEDULE, eventTracker);
+
+      // create a sample curated item
+      const item = await createApprovedItemHelper(db, {
+        title: 'A test story',
+      });
+
+      // create two scheduled entries for this item
+      const existingScheduledEntry1 = await createScheduledItemHelper(db, {
+        approvedItem: item,
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+        scheduledDate: new Date(2050, 4, 4).toISOString(),
+      });
+
+      const existingScheduledEntry2 = await createScheduledItemHelper(db, {
+        approvedItem: item,
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+        scheduledDate: new Date(2050, 4, 5).toISOString(),
+      });
+
+      // And this human-readable (and cross-locale understandable) format
+      // is used in the error message we're anticipating to get.
+      const displayDate = DateTime.fromJSDate(
+        existingScheduledEntry1.scheduledDate
+      ).toFormat('MMM d, y');
+
+      // try to reschedule the second entry for the same date as the first
+      const input: RescheduleScheduledItemInput = {
+        externalId: existingScheduledEntry2.externalId,
+        scheduledDate: '2050-05-04',
+      };
+
+      const result = await server.executeOperation({
+        query: RESCHEDULE_SCHEDULED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.data).to.be.null;
+
+      // Expecting to see a custom error message from the resolver
+      expect(result.errors?.[0].message).to.contain(
+        `This story is already scheduled to appear on ${displayDate}.`
+      );
+
+      expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
+
+      // Check that the ADD_SCHEDULE event was not fired
+      expect(eventTracker.callCount).to.equal(0);
+    });
+
+    it('should fail if user has read-only access', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.READONLY}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const approvedItem = await createApprovedItemHelper(db, {
+        title: 'This is a test',
+      });
+
+      const scheduledItem = await createScheduledItemHelper(db, {
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+        approvedItem,
+        scheduledDate: new Date(2050, 4, 4).toISOString(),
+      });
+
+      const result = await server.executeOperation({
+        query: RESCHEDULE_SCHEDULED_ITEM,
+        variables: {
+          data: {
+            externalId: scheduledItem.externalId,
+            scheduledDate: '2050-05-05',
+          },
+        },
+      });
+
+      // ...without success. There is no data
+      expect(result.data).to.be.null;
+
+      expect(result.errors).not.to.be.null;
+
+      // And there is an access denied error
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+    });
+
+    it("should fail if user doesn't have access to specified scheduled surface", async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_DEDE}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const approvedItem = await createApprovedItemHelper(db, {
+        title: 'This is a test',
+      });
+
+      const scheduledItem = await createScheduledItemHelper(db, {
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+        approvedItem,
+        scheduledDate: new Date(2050, 4, 4).toISOString(),
+      });
+
+      const result = await server.executeOperation({
+        query: RESCHEDULE_SCHEDULED_ITEM,
+        variables: {
+          data: {
+            externalId: scheduledItem.externalId,
+            scheduledDate: '2050-05-05',
+          },
+        },
+      });
+
+      // ...without success. There is no data
+      expect(result.data).to.be.null;
+
+      expect(result.errors).not.to.be.null;
+
+      // And there is an access denied error
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+    });
+
+    it('should succeed if user has access to specified scheduled surface', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_ENUS}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const approvedItem = await createApprovedItemHelper(db, {
+        title: 'This is a test',
+      });
+
+      const scheduledItem = await createScheduledItemHelper(db, {
+        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+        approvedItem,
+        scheduledDate: new Date(2050, 4, 4).toISOString(),
+      });
+
+      const result = await server.executeOperation({
+        query: RESCHEDULE_SCHEDULED_ITEM,
+        variables: {
+          data: {
+            externalId: scheduledItem.externalId,
+            scheduledDate: '2050-05-05',
+          },
+        },
+      });
+
+      // Hooray! There is data
+      expect(result.data).not.to.be.null;
+
+      // And no errors, too!
+      expect(result.errors).to.be.undefined;
     });
   });
 });

--- a/src/admin/resolvers/mutations/ScheduledItem.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.ts
@@ -41,10 +41,7 @@ export async function deleteScheduledItem(
   }
 
   // Check if the user can execute this mutation.
-  if (
-    item &&
-    !context.authenticatedUser.canWriteToSurface(item.scheduledSurfaceGuid)
-  ) {
+  if (!context.authenticatedUser.canWriteToSurface(item.scheduledSurfaceGuid)) {
     throw new AuthenticationError(ACCESS_DENIED_ERROR);
   }
 
@@ -145,10 +142,7 @@ export async function rescheduleScheduledItem(
   }
 
   // Check if the user can execute this mutation.
-  if (
-    item &&
-    !context.authenticatedUser.canWriteToSurface(item.scheduledSurfaceGuid)
-  ) {
+  if (!context.authenticatedUser.canWriteToSurface(item.scheduledSurfaceGuid)) {
     throw new AuthenticationError(ACCESS_DENIED_ERROR);
   }
 

--- a/src/admin/resolvers/mutations/ScheduledItem.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.ts
@@ -1,6 +1,7 @@
 import {
   deleteScheduledItem as dbDeleteScheduledItem,
   createScheduledItem as dbCreateScheduledItem,
+  rescheduleScheduledItem as dbRescheduleScheduledItem,
 } from '../../../database/mutations';
 import { ScheduledItem } from '../../../database/types';
 import {
@@ -11,6 +12,7 @@ import { ScheduledCorpusItemEventType } from '../../../events/types';
 import { UserInputError } from 'apollo-server';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
 import { AuthenticationError } from 'apollo-server-errors';
+import { NotFoundError } from '@pocket-tools/apollo-utils';
 import { IContext } from '../../context';
 
 /**
@@ -31,6 +33,12 @@ export async function deleteScheduledItem(
   const item = await context.db.scheduledItem.findUnique({
     where: { externalId: data.externalId },
   });
+
+  if (!item) {
+    throw new NotFoundError(
+      `Item with ID of '${data.externalId}' could not be found.`
+    );
+  }
 
   // Check if the user can execute this mutation.
   if (
@@ -110,6 +118,67 @@ export async function createScheduledItem(
         } on ${data.scheduledDate.toLocaleString('en-US', {
           dateStyle: 'medium',
         })}.`
+      );
+    }
+
+    // If it's something else, throw the error unchanged.
+    throw new Error(error);
+  }
+}
+
+export async function rescheduleScheduledItem(
+  parent,
+  { data },
+  context: IContext
+): Promise<ScheduledItem> {
+  // Need to fetch the item first to check access privileges.
+  // Note that we do not worry here about an extra hit to the DB
+  // as load on this service will be low.
+  const item = await context.db.scheduledItem.findUnique({
+    where: { externalId: data.externalId },
+  });
+
+  if (!item) {
+    throw new NotFoundError(
+      `Item with ID of '${data.externalId}' could not be found.`
+    );
+  }
+
+  // Check if the user can execute this mutation.
+  if (
+    item &&
+    !context.authenticatedUser.canWriteToSurface(item.scheduledSurfaceGuid)
+  ) {
+    throw new AuthenticationError(ACCESS_DENIED_ERROR);
+  }
+
+  try {
+    const rescheduledItem = await dbRescheduleScheduledItem(
+      context.db,
+      data,
+      context.authenticatedUser.username
+    );
+
+    context.emitScheduledCorpusItemEvent(
+      ScheduledCorpusItemEventType.RESCHEDULE,
+      rescheduledItem
+    );
+
+    return rescheduledItem;
+  } catch (error) {
+    // If it's the duplicate scheduling constraint, catch the error
+    // and send a user-friendly one to the client instead.
+    if (
+      error instanceof PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      throw new UserInputError(
+        `This story is already scheduled to appear on ${data.scheduledDate.toLocaleString(
+          'en-US',
+          {
+            dateStyle: 'medium',
+          }
+        )}.`
       );
     }
 

--- a/src/admin/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/admin/resolvers/mutations/sample-mutations.gql.ts
@@ -65,6 +65,17 @@ export const DELETE_SCHEDULED_ITEM = gql`
   ${ScheduledItemData}
 `;
 
+export const RESCHEDULE_SCHEDULED_ITEM = gql`
+  mutation rescheduleScheduledItem(
+    $data: RescheduleScheduledCuratedCorpusItemInput!
+  ) {
+    rescheduleScheduledCuratedCorpusItem(data: $data) {
+      ...ScheduledItemData
+    }
+  }
+  ${ScheduledItemData}
+`;
+
 export const UPLOAD_APPROVED_ITEM_IMAGE = gql`
   mutation uploadApprovedCuratedCorpusItemImage($image: Upload!) {
     uploadApprovedCuratedCorpusItemImage(data: $image) {

--- a/src/database/mutations/ScheduledItem.ts
+++ b/src/database/mutations/ScheduledItem.ts
@@ -74,7 +74,6 @@ export async function rescheduleScheduledItem(
     data: {
       scheduledDate: data.scheduledDate,
       updatedBy: username,
-      updatedAt: new Date(),
     },
     include: {
       approvedItem: true,

--- a/src/database/mutations/index.ts
+++ b/src/database/mutations/index.ts
@@ -4,4 +4,8 @@ export {
   updateApprovedItem,
 } from './ApprovedItem';
 export { createRejectedItem } from './RejectedItem';
-export { createScheduledItem, deleteScheduledItem } from './ScheduledItem';
+export {
+  createScheduledItem,
+  deleteScheduledItem,
+  rescheduleScheduledItem,
+} from './ScheduledItem';

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -104,6 +104,11 @@ export type CreateScheduledItemInput = {
   scheduledDate: string;
 };
 
+export type RescheduleScheduledItemInput = {
+  externalId: string;
+  scheduledDate: string;
+};
+
 // Types for the public `scheduledSurface` query.
 export type CorpusItem = {
   // This is `externalId` in the DB schema and Admin API

--- a/src/events/snowplow/types.ts
+++ b/src/events/snowplow/types.ts
@@ -9,7 +9,8 @@ export type SnowplowEventType =
   | 'reviewed_corpus_item_removed'
   | 'reviewed_corpus_item_rejected'
   | 'scheduled_corpus_item_added'
-  | 'scheduled_corpus_item_removed';
+  | 'scheduled_corpus_item_removed'
+  | 'scheduled_corpus_item_rescheduled';
 
 export const ReviewedItemSnowplowEventMap: Record<
   ReviewedCorpusItemEventTypeString,
@@ -27,4 +28,5 @@ export const ScheduledItemSnowplowEventMap: Record<
 > = {
   ADD_SCHEDULE: 'scheduled_corpus_item_added',
   REMOVE_SCHEDULE: 'scheduled_corpus_item_removed',
+  RESCHEDULE: 'scheduled_corpus_item_rescheduled',
 };

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -11,6 +11,7 @@ export enum ReviewedCorpusItemEventType {
 export enum ScheduledCorpusItemEventType {
   ADD_SCHEDULE = 'ADD_SCHEDULE',
   REMOVE_SCHEDULE = 'REMOVE_SCHEDULE',
+  RESCHEDULE = 'RESCHEDULE',
 }
 
 export type ReviewedCorpusItemEventTypeString =


### PR DESCRIPTION
## Goal

add a mutation for rescheduling a scheduled item

- remove superfluous server start/stop calls in test file
- add a new snowplow type for reschedule
- refactor delete scheduled item a bit to be more effecient

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1354
