### PR TITLE
fix: [BACK-1360] Fix indecipherable error messages

### DIFF
--- a/src/admin/server.ts
+++ b/src/admin/server.ts
@@ -5,7 +5,7 @@ import { typeDefsAdmin } from '../typeDefs';
 import { resolvers as resolversAdmin } from './resolvers';
 import responseCachePlugin from 'apollo-server-plugin-response-cache';
 import { GraphQLRequestContext } from 'apollo-server-types';
-import { sentryPlugin, errorHandler } from '@pocket-tools/apollo-utils';
+import { sentryPlugin } from '@pocket-tools/apollo-utils';
 import { ContextManager } from './context';
 import {
   ApolloServerPluginLandingPageDisabled,
@@ -28,7 +28,6 @@ export function getServer(contextFactory: ContextFactory): ApolloServer {
     schema: buildSubgraphSchema([
       { typeDefs: typeDefsAdmin, resolvers: resolversAdmin },
     ]),
-    formatError: errorHandler,
     plugins: [
       //Copied from Apollo docs, the sessionID signifies if we should separate out caches by user.
       responseCachePlugin({


### PR DESCRIPTION
## Goal

To fix a bug - "when you try to add an item to the corpus that is in the rejected corpus, you get an INTERNAL_SERVER_ERROR. we should display a helpful error message instead."

The error handler from `apollo-utils` masks errors that we want to expose to end users (aka the Curation Tools Frontend) of the admin subgraph. Removing the error handler appears to be the most sensible option.

Note that integration tests were and are passing unchanged as they use a separate admin server bootstrap script without the Sentry plugin and that script was never updated to use the error handler, so the bug was not discovered until testing the frontend functionality made it apparent.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1360