### PR TITLE
feat(federation): [BACK-1365] make approved curated item available in the admin graph via federation

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -119,7 +119,7 @@ type ScheduledSurface {
 """
 A prospective story that has been reviewed by the curators and saved to the curated corpus.
 """
-type ApprovedCuratedCorpusItem {
+type ApprovedCuratedCorpusItem @key(fields: "url") {
     """
     An alternative primary key in UUID format that is generated on creation.
     """

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -18,17 +18,34 @@ import {
   rescheduleScheduledItem,
 } from './mutations/ScheduledItem';
 import { GraphQLUpload } from 'graphql-upload';
+import { getApprovedItemByUrl as dbGetApprovedItemByUrl } from '../../database/queries';
 
 export const resolvers = {
   // Map the Upload scalar to graphql-upload
   Upload: GraphQLUpload,
   // The custom scalars from GraphQL-Scalars that we find useful.
   Date: DateResolver,
-  // Our own entities that need timestamp conversion, hence field resolvers
-  // everywhere for values returned by `createdAt` and `updatedAt` fields.
+
   ApprovedCuratedCorpusItem: {
+    // Our own entities that need timestamp conversion, hence field resolvers
+    // everywhere for values returned by `createdAt` and `updatedAt` fields.
     createdAt: UnixTimestampResolver,
     updatedAt: UnixTimestampResolver,
+
+    // Resolve reference to approved items by the `url` field.
+    __resolveReference: async (item, { db }) => {
+      const { url } = item;
+
+      /**
+       * Even though it appears that we're querying the partner up to four times
+       * to retrieve the information for the four fields below, Prisma is actually
+       * batching the queries behind the scenes and there is no performance hit.
+       *
+       * It is also returning items in the correct order for us.
+       * Docs here: https://www.prisma.io/docs/guides/performance-and-optimization/query-optimization-performance
+       */
+      return dbGetApprovedItemByUrl(db, url);
+    },
   },
   RejectedCuratedCorpusItem: {
     createdAt: UnixTimestampResolver,

--- a/src/admin/resolvers/queries/sample-queries.gql.ts
+++ b/src/admin/resolvers/queries/sample-queries.gql.ts
@@ -91,3 +91,14 @@ export const GET_SCHEDULED_SURFACES_FOR_USER = gql`
     }
   }
 `;
+
+export const APPROVED_ITEM_REFERENCE_RESOLVER = gql`
+  query ($representations: [_Any!]!) {
+    _entities(representations: $representations) {
+      ... on ApprovedCuratedCorpusItem {
+        ...CuratedItemData
+      }
+    }
+  }
+  ${CuratedItemData}
+`;


### PR DESCRIPTION
## Goal

- Approved item can now be resolved via the `url` field in other subgraphs.

- Data loaders are not required as Prisma does the heavy lifting for us.

- Tests added for the new reference resolver.


## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1365