### PR TITLE
make node fetch to ignore https error

### DIFF
--- a/src/admin/aws/utils.ts
+++ b/src/admin/aws/utils.ts
@@ -2,6 +2,7 @@ import { FileUpload } from 'graphql-upload';
 import fetch from 'node-fetch';
 import mime from 'mime-types';
 import { InvalidImageUrl } from './errors';
+import * as https from 'https';
 
 /**
  * Fetch image from URL and transform into a GraphQL FileUpload object
@@ -9,7 +10,13 @@ import { InvalidImageUrl } from './errors';
  */
 export async function getFileUploadFromUrl(url: string): Promise<FileUpload> {
   try {
-    const res = await fetch(url);
+    const httpsAgent = new https.Agent({
+      rejectUnauthorized: false,
+    });
+
+    const res = await fetch(url, {
+      agent: httpsAgent,
+    });
     const contentType = res.headers.get('content-type');
 
     checkValidImageContentType(contentType);


### PR DESCRIPTION
## Goal 

make node fetch ignore https error

e.g this image: https://static.hollywoodreporter.com/wp-content/uploads/2021/04/MG_5536-2-SPLASH-2021-1617664574-1024x576.jpg

sentry error: https://sentry.io/organizations/pocket/issues/3129328587/events/c6a1b902daaa4b71a2bdbdab5c1d362b/?environment=development&project=5938284&statsPeriod=1h