### PR TITLE
chore: [BACK-1319] Remove `Curated` from query and mutation names

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -119,9 +119,9 @@ type ScheduledSurface {
 }
 
 """
-A prospective story that has been reviewed by the curators and saved to the curated corpus.
+A prospective story that has been reviewed by the curators and saved to the corpus.
 """
-type ApprovedCuratedCorpusItem @key(fields: "url") {
+type ApprovedCorpusItem @key(fields: "url") {
     """
     An alternative primary key in UUID format that is generated on creation.
     """
@@ -202,7 +202,7 @@ type ApprovedCuratedCorpusItem @key(fields: "url") {
 """
 A prospective story that has been rejected by the curators.
 """
-type RejectedCuratedCorpusItem {
+type RejectedCorpusItem {
     """
     An alternative primary key in UUID format that is generated on creation.
     """
@@ -249,7 +249,7 @@ type RejectedCuratedCorpusItem {
 """
 An edge in a connection.
 """
-type ApprovedCuratedCorpusItemEdge {
+type ApprovedCorpusItemEdge {
     """
     A cursor for use in pagination.
     """
@@ -257,10 +257,10 @@ type ApprovedCuratedCorpusItemEdge {
     """
     The Approved Item at the end of the edge.
     """
-    node: ApprovedCuratedCorpusItem!
+    node: ApprovedCorpusItem!
 }
 
-type ApprovedCuratedCorpusImageUrl {
+type ApprovedCorpusImageUrl {
     """
     The url of the image stored in the s3 bucket
     """
@@ -268,27 +268,27 @@ type ApprovedCuratedCorpusImageUrl {
 }
 
 """
-An edge in a connection for RejectedCuratedCorpusItem type.
+An edge in a connection for RejectedCorpusItem type.
 """
-type RejectedCuratedCorpusItemEdge {
+type RejectedCorpusItemEdge {
     """
     A cursor for use in pagination.
     """
     cursor: String!
     """
-    The Rejected Curated Item at the end of the edge.
+    The Rejected Item at the end of the edge.
     """
-    node: RejectedCuratedCorpusItem!
+    node: RejectedCorpusItem!
 }
 
 """
 The connection type for Approved Item.
 """
-type ApprovedCuratedCorpusItemConnection {
+type ApprovedCorpusItemConnection {
     """
     A list of edges.
     """
-    edges: [ApprovedCuratedCorpusItemEdge!]!
+    edges: [ApprovedCorpusItemEdge!]!
     """
     Information to aid in pagination.
     """
@@ -300,13 +300,13 @@ type ApprovedCuratedCorpusItemConnection {
 }
 
 """
-The connection type for Rejected Curated Item.
+The connection type for Rejected Item.
 """
-type RejectedCuratedCorpusItemConnection {
+type RejectedCorpusItemConnection {
     """
     A list of edges.
     """
-    edges: [RejectedCuratedCorpusItemEdge!]!
+    edges: [RejectedCorpusItemEdge!]!
     """
     Information to aid in pagination.
     """
@@ -321,7 +321,7 @@ type RejectedCuratedCorpusItemConnection {
 A scheduled entry for an Approved Item to appear on a Scheduled Surface.
 For example, a story that is scheduled to appear on December 31st, 2021 on the New Tab in Firefox for the US audience.
 """
-type ScheduledCuratedCorpusItem {
+type ScheduledCorpusItem {
     """
     An alternative primary key in UUID format that is generated on creation.
     """
@@ -350,17 +350,17 @@ type ScheduledCuratedCorpusItem {
     """
     The associated Approved Item.
     """
-    approvedItem: ApprovedCuratedCorpusItem!
+    approvedItem: ApprovedCorpusItem!
     """
-    The GUID of this schedudedSurface to which this item is scheduled. Example: 'NEW_TAB_EN_US'.
+    The GUID of this scheduledSurface to which this item is scheduled. Example: 'NEW_TAB_EN_US'.
     """
     scheduledSurfaceGuid: ID!
 }
 
 """
-The shape of the result returned by the getScheduledCuratedCorpusItems query.
+The shape of the result returned by the getScheduledCorpusItems query.
 """
-type ScheduledCuratedCorpusItemsResult {
+type ScheduledCorpusItemsResult {
     """
     The date items are scheduled for, in YYYY-MM-DD format.
     """
@@ -380,13 +380,13 @@ type ScheduledCuratedCorpusItemsResult {
     """
     An array of items for a given Scheduled Surface
     """
-    items: [ScheduledCuratedCorpusItem!]!
+    items: [ScheduledCorpusItem!]!
 }
 
 """
-Available fields for filtering ApprovedCuratedCorpusItems.
+Available fields for filtering Approved Items.
 """
-input ApprovedCuratedCorpusItemFilter {
+input ApprovedCorpusItemFilter {
     """
     Optional filter on the URL field. Returns partial matches.
     """
@@ -411,9 +411,9 @@ input ApprovedCuratedCorpusItemFilter {
 }
 
 """
-Available fields for filtering RejectedCuratedCorpusItems.
+Available fields for filtering Rejected Items.
 """
-input RejectedCuratedCorpusItemFilter {
+input RejectedCorpusItemFilter {
     """
     Optional filter on the URL field. Returns partial matches.
     """
@@ -436,7 +436,7 @@ input RejectedCuratedCorpusItemFilter {
 """
 Available fields for filtering scheduled items for a given Scheduled Surface.
 """
-input ScheduledCuratedCorpusItemsFilterInput {
+input ScheduledCorpusItemsFilterInput {
     """
     The GUID of the Scheduled Surface. Example: 'NEW_TAB_EN_US'.
     """
@@ -454,7 +454,7 @@ input ScheduledCuratedCorpusItemsFilterInput {
 """
 Input data for creating an Approved Item and optionally scheduling this item to appear on a Scheduled Surface.
 """
-input CreateApprovedCuratedCorpusItemInput {
+input CreateApprovedCorpusItemInput {
     """
     The GUID of the corresponding Prospect ID. Will be empty for manually added items.
     """
@@ -523,7 +523,7 @@ input CreateApprovedCuratedCorpusItemInput {
 Input data for loading an Approved Item via an automated process and optionally scheduling
 this item to appear on a Scheduled Surface.
 """
-input ImportApprovedCuratedCorpusItemInput {
+input ImportApprovedCorpusItemInput {
     """
     The URL of the Approved Item.
     """
@@ -597,21 +597,21 @@ input ImportApprovedCuratedCorpusItemInput {
 """
 The data that the loadApprovedCuratedCorpusItem mutation returns on success.
 """
-type ImportApprovedCuratedCorpusItemPayload {
+type ImportApprovedCorpusItemPayload {
     """
     The approved item, as created by an automated process.
     """
-    approvedItem: ApprovedCuratedCorpusItem!
+    approvedItem: ApprovedCorpusItem!
     """
     The scheduled entry that is created by an automated process at the same time.
     """
-    scheduledItem: ScheduledCuratedCorpusItem!
+    scheduledItem: ScheduledCorpusItem!
 }
 
 """
 Input data for updating an Approved Item.
 """
-input UpdateApprovedCuratedCorpusItemInput {
+input UpdateApprovedCorpusItemInput {
     """
     Approved Item ID.
     """
@@ -655,7 +655,7 @@ input UpdateApprovedCuratedCorpusItemInput {
 """
 Input data for rejecting an Approved Item.
 """
-input RejectApprovedCuratedCorpusItemInput {
+input RejectApprovedCorpusItemInput {
     """
     Approved Item ID.
     """
@@ -669,7 +669,7 @@ input RejectApprovedCuratedCorpusItemInput {
 """
 Input data for creating a Rejected Item.
 """
-input CreateRejectedCuratedCorpusItemInput {
+input CreateRejectedCorpusItemInput {
     """
     The GUID of the corresponding Prospect ID. Will be empty for manually added item.
     """
@@ -704,7 +704,7 @@ input CreateRejectedCuratedCorpusItemInput {
 """
 Input data for creating a scheduled entry for an Approved Item on a Scheduled Surface.
 """
-input CreateScheduledCuratedCorpusItemInput {
+input CreateScheduledCorpusItemInput {
     """
     The ID of the Approved Item that needs to be scheduled.
     """
@@ -722,7 +722,7 @@ input CreateScheduledCuratedCorpusItemInput {
 """
 Input data for rescheduling a scheduled item for a Scheduled Surface.
 """
-input RescheduleScheduledCuratedCorpusItemInput {
+input RescheduleScheduledCorpusItemInput {
     """
     ID of the scheduled item. A string in UUID format.
     """
@@ -736,7 +736,7 @@ input RescheduleScheduledCuratedCorpusItemInput {
 """
 Input data for deleting a scheduled item for a Scheduled Surface.
 """
-input DeleteScheduledCuratedCorpusItemInput {
+input DeleteScheduledCorpusItemInput {
     """
     ID of the scheduled item. A string in UUID format.
     """
@@ -745,41 +745,41 @@ input DeleteScheduledCuratedCorpusItemInput {
 
 type Query {
     """
-    Retrieves a paginated, filterable list of ApprovedCuratedCorpusItems.
+    Retrieves a paginated, filterable list of Approved Items.
     """
-    getApprovedCuratedCorpusItems(
-        filters: ApprovedCuratedCorpusItemFilter
+    getApprovedCorpusItems(
+        filters: ApprovedCorpusItemFilter
         pagination: PaginationInput
-    ): ApprovedCuratedCorpusItemConnection!
+    ): ApprovedCorpusItemConnection!
 
     """
-    Retrieves a paginated, filterable list of RejectedCuratedCorpusItems.
+    Retrieves a paginated, filterable list of Rejected Items.
     """
-    getRejectedCuratedCorpusItems(
-        filters: RejectedCuratedCorpusItemFilter
+    getRejectedCorpusItems(
+        filters: RejectedCorpusItemFilter
         pagination: PaginationInput
-    ): RejectedCuratedCorpusItemConnection!
+    ): RejectedCorpusItemConnection!
 
     """
     Retrieves a list of Approved Items that are scheduled to appear on a Scheduled Surface.
     """
-    getScheduledCuratedCorpusItems(
+    getScheduledCorpusItems(
         """
         Required arguments to narrow down scheduled items to a specific Scheduled Surface
         between the supplied start and end dates.
         """
-        filters: ScheduledCuratedCorpusItemsFilterInput!
-    ): [ScheduledCuratedCorpusItemsResult!]!
+        filters: ScheduledCorpusItemsFilterInput!
+    ): [ScheduledCorpusItemsResult!]!
 
     """
-    Retrieves an approved curated item with the given URL.
+    Retrieves an approved item with the given URL.
     """
-    getApprovedCuratedCorpusItemByUrl(
+    getApprovedCorpusItemByUrl(
         """
         The URL of the approved item.
         """
         url: String!
-    ): ApprovedCuratedCorpusItem
+    ): ApprovedCorpusItem
 
     """
     Retrieves all ScheduledSurfaces available to the given SSO user. Requires an Authorization header.
@@ -791,64 +791,64 @@ type Mutation {
     """
     Creates an Approved Item and optionally schedules it to appear on a Scheduled Surface.
     """
-    createApprovedCuratedCorpusItem(
-        data: CreateApprovedCuratedCorpusItemInput!
-    ): ApprovedCuratedCorpusItem!
+    createApprovedCorpusItem(
+        data: CreateApprovedCorpusItemInput!
+    ): ApprovedCorpusItem!
 
     """
     Lets an automated process create an Approved Item and optionally schedule it to appear
     on a Scheduled Surface.
     """
-    importApprovedCuratedCorpusItem(
-        data: ImportApprovedCuratedCorpusItemInput!
-    ): ImportApprovedCuratedCorpusItemPayload!
+    importApprovedCorpusItem(
+        data: ImportApprovedCorpusItemInput!
+    ): ImportApprovedCorpusItemPayload!
 
     """
     Creates a Rejected Item.
     """
-    createRejectedCuratedCorpusItem(
-        data: CreateRejectedCuratedCorpusItemInput!
-    ): RejectedCuratedCorpusItem!
+    createRejectedCorpusItem(
+        data: CreateRejectedCorpusItemInput!
+    ): RejectedCorpusItem!
 
     """
     Updates an Approved Item.
     """
-    updateApprovedCuratedCorpusItem(
-        data: UpdateApprovedCuratedCorpusItemInput!
-    ): ApprovedCuratedCorpusItem!
+    updateApprovedCorpusItem(
+        data: UpdateApprovedCorpusItemInput!
+    ): ApprovedCorpusItem!
 
     """
     Rejects an Approved Item: deletes it from the corpus and creates a Rejected Item instead.
     """
-    rejectApprovedCuratedCorpusItem(
-        data: RejectApprovedCuratedCorpusItemInput!
-    ): ApprovedCuratedCorpusItem!
+    rejectApprovedCorpusItem(
+        data: RejectApprovedCorpusItemInput!
+    ): ApprovedCorpusItem!
 
     """
     Creates a Scheduled Surface Scheduled Item.
     """
-    createScheduledCuratedCorpusItem(
-        data: CreateScheduledCuratedCorpusItemInput!
-    ): ScheduledCuratedCorpusItem!
+    createScheduledCorpusItem(
+        data: CreateScheduledCorpusItemInput!
+    ): ScheduledCorpusItem!
 
     """
     Deletes an item from a Scheduled Surface.
     """
-    deleteScheduledCuratedCorpusItem(
-        data: DeleteScheduledCuratedCorpusItemInput!
-    ): ScheduledCuratedCorpusItem!
+    deleteScheduledCorpusItem(
+        data: DeleteScheduledCorpusItemInput!
+    ): ScheduledCorpusItem!
 
     """
     Updates the scheduled date of a Scheduled Surface Scheduled Item.
     """
-    rescheduleScheduledCuratedCorpusItem(
-        data: RescheduleScheduledCuratedCorpusItemInput!
-    ): ScheduledCuratedCorpusItem!
+    rescheduleScheduledCorpusItem(
+        data: RescheduleScheduledCorpusItemInput!
+    ): ScheduledCorpusItem!
 
     """
-    Uploads an image to S3 for an Approved Curated Corpus Item
+    Uploads an image to S3 for an Approved Item
     """
-    uploadApprovedCuratedCorpusItemImage(
+    uploadApprovedCorpusItemImage(
         data: Upload!
-    ): ApprovedCuratedCorpusImageUrl!
+    ): ApprovedCorpusImageUrl!
 }

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -26,7 +26,7 @@ export const resolvers = {
   // The custom scalars from GraphQL-Scalars that we find useful.
   Date: DateResolver,
 
-  ApprovedCuratedCorpusItem: {
+  ApprovedCorpusItem: {
     // Our own entities that need timestamp conversion, hence field resolvers
     // everywhere for values returned by `createdAt` and `updatedAt` fields.
     createdAt: UnixTimestampResolver,
@@ -47,31 +47,31 @@ export const resolvers = {
       return dbGetApprovedItemByUrl(db, url);
     },
   },
-  RejectedCuratedCorpusItem: {
+  RejectedCorpusItem: {
     createdAt: UnixTimestampResolver,
   },
-  ScheduledCuratedCorpusItem: {
+  ScheduledCorpusItem: {
     createdAt: UnixTimestampResolver,
     updatedAt: UnixTimestampResolver,
   },
   // The queries available
   Query: {
-    getApprovedCuratedCorpusItems: getApprovedItems,
-    getRejectedCuratedCorpusItems: getRejectedItems,
-    getScheduledCuratedCorpusItems: getScheduledItems,
-    getApprovedCuratedCorpusItemByUrl: getApprovedItemByUrl,
+    getApprovedCorpusItems: getApprovedItems,
+    getRejectedCorpusItems: getRejectedItems,
+    getScheduledCorpusItems: getScheduledItems,
+    getApprovedCorpusItemByUrl: getApprovedItemByUrl,
     getScheduledSurfacesForUser: getScheduledSurfacesForUser,
   },
   // Mutations that we need in the admin interface
   Mutation: {
-    createApprovedCuratedCorpusItem: createApprovedItem,
-    rejectApprovedCuratedCorpusItem: rejectApprovedItem,
-    updateApprovedCuratedCorpusItem: updateApprovedItem,
-    createRejectedCuratedCorpusItem: createRejectedItem,
-    createScheduledCuratedCorpusItem: createScheduledItem,
-    deleteScheduledCuratedCorpusItem: deleteScheduledItem,
-    rescheduleScheduledCuratedCorpusItem: rescheduleScheduledItem,
-    uploadApprovedCuratedCorpusItemImage: uploadApprovedItemImage,
-    importApprovedCuratedCorpusItem: importApprovedItem,
+    createApprovedCorpusItem: createApprovedItem,
+    rejectApprovedCorpusItem: rejectApprovedItem,
+    updateApprovedCorpusItem: updateApprovedItem,
+    createRejectedCorpusItem: createRejectedItem,
+    createScheduledCorpusItem: createScheduledItem,
+    deleteScheduledCorpusItem: deleteScheduledItem,
+    rescheduleScheduledCorpusItem: rescheduleScheduledItem,
+    uploadApprovedCorpusItemImage: uploadApprovedItemImage,
+    importApprovedCorpusItem: importApprovedItem,
   },
 };

--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -36,7 +36,7 @@ import {
   MozillaAccessGroup,
   Topics,
 } from '../../../shared/types';
-import { ImportApprovedCuratedCorpusItemInput } from '../types';
+import { ImportApprovedCorpusItemInput } from '../types';
 import nock from 'nock';
 
 describe('mutations: ApprovedItem', () => {
@@ -63,7 +63,7 @@ describe('mutations: ApprovedItem', () => {
     await clearDb(db);
   });
 
-  describe('createApprovedCuratedCorpusItem mutation', () => {
+  describe('createApprovedCorpusItem mutation', () => {
     // a standard set of inputs for this mutation
     let input: CreateApprovedItemInput;
 
@@ -101,13 +101,11 @@ describe('mutations: ApprovedItem', () => {
 
       // Expect to see all the input data we supplied in the Approved Item
       // returned by the mutation
-      expect(result.data?.createApprovedCuratedCorpusItem).to.deep.include(
-        input
-      );
+      expect(result.data?.createApprovedCorpusItem).to.deep.include(input);
 
       // The `createdBy` field should now be the SSO username of the user
       // who updated this record
-      expect(result.data?.createApprovedCuratedCorpusItem.createdBy).to.equal(
+      expect(result.data?.createApprovedCorpusItem.createdBy).to.equal(
         headers.username
       );
 
@@ -121,7 +119,7 @@ describe('mutations: ApprovedItem', () => {
       // 3- Event has the right entity passed to it.
       expect(
         await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(result.data?.createApprovedCuratedCorpusItem.externalId);
+      ).to.equal(result.data?.createApprovedCorpusItem.externalId);
     });
 
     it('should create an approved item without a prospectId', async () => {
@@ -145,13 +143,13 @@ describe('mutations: ApprovedItem', () => {
 
       // Expect to see all the input data we supplied in the Approved Item
       // returned by the mutation
-      expect(result.data?.createApprovedCuratedCorpusItem).to.deep.include(
+      expect(result.data?.createApprovedCorpusItem).to.deep.include(
         inputWithoutProspectId
       );
 
       // The `createdBy` field should now be the SSO username of the user
       // who updated this record
-      expect(result.data?.createApprovedCuratedCorpusItem.createdBy).to.equal(
+      expect(result.data?.createApprovedCorpusItem.createdBy).to.equal(
         headers.username
       );
 
@@ -165,7 +163,7 @@ describe('mutations: ApprovedItem', () => {
       // 3- Event has the right entity passed to it.
       expect(
         await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(result.data?.createApprovedCuratedCorpusItem.externalId);
+      ).to.equal(result.data?.createApprovedCorpusItem.externalId);
     });
 
     it('should fail to create an approved item with a duplicate URL', async () => {
@@ -253,13 +251,11 @@ describe('mutations: ApprovedItem', () => {
       // input values from the input before comparison.
       delete input.scheduledDate;
       delete input.scheduledSurfaceGuid;
-      expect(result.data?.createApprovedCuratedCorpusItem).to.deep.include(
-        input
-      );
+      expect(result.data?.createApprovedCorpusItem).to.deep.include(input);
 
       // The `createdBy` field should now be the SSO username of the user
       // who updated this record
-      expect(result.data?.createApprovedCuratedCorpusItem.createdBy).to.equal(
+      expect(result.data?.createApprovedCorpusItem.createdBy).to.equal(
         headers.username
       );
 
@@ -282,7 +278,7 @@ describe('mutations: ApprovedItem', () => {
       // 3- Events have the right entities passed to it.
       expect(
         await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(result.data?.createApprovedCuratedCorpusItem.externalId);
+      ).to.equal(result.data?.createApprovedCorpusItem.externalId);
 
       // Since we don't return the scheduled item alongside the curated item
       // in the result of this mutation, there is no exact value to compare it to.
@@ -382,7 +378,7 @@ describe('mutations: ApprovedItem', () => {
     });
   });
 
-  describe('updateApprovedCuratedCorpusItem mutation', () => {
+  describe('updateApprovedCorpusItem mutation', () => {
     let item: ApprovedItem;
     let input: UpdateApprovedItemInput;
 
@@ -417,16 +413,16 @@ describe('mutations: ApprovedItem', () => {
       });
 
       // External ID should be unchanged
-      expect(data?.updateApprovedCuratedCorpusItem.externalId).to.equal(
+      expect(data?.updateApprovedCorpusItem.externalId).to.equal(
         item.externalId
       );
 
       // Updated properties should be... updated
-      expect(data?.updateApprovedCuratedCorpusItem).to.deep.include(input);
+      expect(data?.updateApprovedCorpusItem).to.deep.include(input);
 
       // The `updatedBy` field should now be the SSO username of the user
       // who updated this record
-      expect(data?.updateApprovedCuratedCorpusItem.updatedBy).to.equal(
+      expect(data?.updateApprovedCorpusItem.updatedBy).to.equal(
         headers.username
       );
 
@@ -440,7 +436,7 @@ describe('mutations: ApprovedItem', () => {
       // 3- Event has the right entity passed to it.
       expect(
         await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(data?.updateApprovedCuratedCorpusItem.externalId);
+      ).to.equal(data?.updateApprovedCorpusItem.externalId);
     });
 
     it('should succeed if user has access to one of scheduled surfaces', async () => {
@@ -464,16 +460,16 @@ describe('mutations: ApprovedItem', () => {
       });
 
       // External ID should be unchanged
-      expect(data?.updateApprovedCuratedCorpusItem.externalId).to.equal(
+      expect(data?.updateApprovedCorpusItem.externalId).to.equal(
         item.externalId
       );
 
       // Updated properties should be... updated
-      expect(data?.updateApprovedCuratedCorpusItem).to.deep.include(input);
+      expect(data?.updateApprovedCorpusItem).to.deep.include(input);
 
       // The `updatedBy` field should now be the SSO username of the user
       // who updated this record
-      expect(data?.updateApprovedCuratedCorpusItem.updatedBy).to.equal(
+      expect(data?.updateApprovedCorpusItem.updatedBy).to.equal(
         headers.username
       );
 
@@ -487,7 +483,7 @@ describe('mutations: ApprovedItem', () => {
       // 3- Event has the right entity passed to it.
       expect(
         await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(data?.updateApprovedCuratedCorpusItem.externalId);
+      ).to.equal(data?.updateApprovedCorpusItem.externalId);
 
       await server.stop();
     });
@@ -586,7 +582,7 @@ describe('mutations: ApprovedItem', () => {
     });
   });
 
-  describe('rejectApprovedCuratedCorpusItem mutation', () => {
+  describe('rejectApprovedCorpusItem mutation', () => {
     it('moves a corpus item from the approved corpus to the rejection pile', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
@@ -614,33 +610,33 @@ describe('mutations: ApprovedItem', () => {
 
       // On success, mutation should return the deleted approved item.
       // Let's verify the id.
-      expect(result.data?.rejectApprovedCuratedCorpusItem.externalId).to.equal(
+      expect(result.data?.rejectApprovedCorpusItem.externalId).to.equal(
         item.externalId
       );
 
       // The `updatedBy` field should now be the SSO username of the user
       // who updated this record
-      expect(result.data?.rejectApprovedCuratedCorpusItem.updatedBy).to.equal(
+      expect(result.data?.rejectApprovedCorpusItem.updatedBy).to.equal(
         headers.username
       );
 
       // There should be a rejected item created. Since we always truncate
       // the database before every test, it is safe to assume that the
-      // `getRejectedCuratedCorpusItems` query will contain the one item
+      // `getRejectedCorpusItems` query will contain the one item
       // that was created by this mutation.
       const { data: queryData } = await server.executeOperation({
         query: GET_REJECTED_ITEMS,
       });
       // There should be one rejected item in there...
-      expect(queryData?.getRejectedCuratedCorpusItems.totalCount).to.equal(1);
+      expect(queryData?.getRejectedCorpusItems.totalCount).to.equal(1);
       // ...and its URL should match that of the deleted Approved Item.
-      expect(
-        queryData?.getRejectedCuratedCorpusItems.edges[0].node.url
-      ).to.equal(item.url);
+      expect(queryData?.getRejectedCorpusItems.edges[0].node.url).to.equal(
+        item.url
+      );
       // The `createdBy` field should now be the SSO username of the user
       // who updated this record
       expect(
-        queryData?.getRejectedCuratedCorpusItems.edges[0].node.createdBy
+        queryData?.getRejectedCorpusItems.edges[0].node.createdBy
       ).to.equal(headers.username);
 
       // Check that the REMOVE_ITEM and REJECT_ITEM events were fired successfully.
@@ -652,7 +648,7 @@ describe('mutations: ApprovedItem', () => {
       );
       expect(
         await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(result.data?.rejectApprovedCuratedCorpusItem.externalId);
+      ).to.equal(result.data?.rejectApprovedCorpusItem.externalId);
 
       // The REJECT_ITEM event sends through the newly created Rejected Item.
       expect(await eventTracker.getCall(1).args[0].eventType).to.equal(
@@ -660,7 +656,7 @@ describe('mutations: ApprovedItem', () => {
       );
       expect(
         await eventTracker.getCall(0).args[0].reviewedCorpusItem.url
-      ).to.equal(queryData?.getRejectedCuratedCorpusItems.edges[0].node.url);
+      ).to.equal(queryData?.getRejectedCorpusItems.edges[0].node.url);
     });
 
     it('should fail if externalId of approved item is not valid', async () => {
@@ -829,7 +825,7 @@ describe('mutations: ApprovedItem', () => {
     });
   });
 
-  describe('uploadApprovedCuratedCorpusItemImage mutation', () => {
+  describe('uploadApprovedCorpusItemImage mutation', () => {
     const testFilePath = __dirname + '/test-image.jpeg';
 
     beforeEach(() => {
@@ -863,15 +859,13 @@ describe('mutations: ApprovedItem', () => {
       );
 
       expect(errors).to.be.undefined;
-      expect(data).to.have.keys('uploadApprovedCuratedCorpusItemImage');
-      expect(data?.uploadApprovedCuratedCorpusItemImage.url).to.match(
-        urlPattern
-      );
+      expect(data).to.have.keys('uploadApprovedCorpusItemImage');
+      expect(data?.uploadApprovedCorpusItemImage.url).to.match(urlPattern);
     });
   });
 
-  describe('importApprovedCuratedCorpusItem mutation', () => {
-    const input: ImportApprovedCuratedCorpusItemInput = {
+  describe('importApprovedCorpusItem mutation', () => {
+    const input: ImportApprovedCorpusItemInput = {
       url: 'https://test.com/docker',
       title: 'Find Out How I Cured My Docker In 2 Days',
       excerpt: 'A short summary of what this story is about',
@@ -961,10 +955,8 @@ describe('mutations: ApprovedItem', () => {
         variables: { data: input },
       });
 
-      const approvedItem =
-        result.data?.importApprovedCuratedCorpusItem.approvedItem;
-      const scheduledItem =
-        result.data?.importApprovedCuratedCorpusItem.scheduledItem;
+      const approvedItem = result.data?.importApprovedCorpusItem.approvedItem;
+      const scheduledItem = result.data?.importApprovedCorpusItem.scheduledItem;
 
       // Check approvedItem
       const urlPrefix = config.aws.s3.localEndpoint;
@@ -1017,10 +1009,10 @@ describe('mutations: ApprovedItem', () => {
         variables: { data: input },
       });
 
-      const approvedItem =
-        result.data?.importApprovedCuratedCorpusItem.approvedItem;
-      const scheduledItem =
-        result.data?.importApprovedCuratedCorpusItem.scheduledItem;
+      const approvedItem = result.data?.importApprovedCorpusItem.approvedItem;
+      result.data?.importApprovedCorpusItem.approvedItem;
+      const scheduledItem = result.data?.importApprovedCorpusItem.scheduledItem;
+      result.data?.importApprovedCorpusItem.scheduledItem;
 
       // Check approvedItem
       expect(approvedItem.url).to.equal(input.url);
@@ -1053,10 +1045,10 @@ describe('mutations: ApprovedItem', () => {
         variables: { data: input },
       });
 
-      const approvedItem =
-        result.data?.importApprovedCuratedCorpusItem.approvedItem;
-      const scheduledItem =
-        result.data?.importApprovedCuratedCorpusItem.scheduledItem;
+      const approvedItem = result.data?.importApprovedCorpusItem.approvedItem;
+      result.data?.importApprovedCorpusItem.approvedItem;
+      const scheduledItem = result.data?.importApprovedCorpusItem.scheduledItem;
+      result.data?.importApprovedCorpusItem.scheduledItem;
 
       // Check approvedItem
       expect(approvedItem.url).to.equal(input.url);
@@ -1097,7 +1089,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
     await clearDb(db);
   });
 
-  describe('createApprovedCuratedCorpusItem mutation', () => {
+  describe('createApprovedCorpusItem mutation', () => {
     it('should succeed if user has access to one of scheduled surfaces', async () => {
       // set up event tracking
       const eventTracker = sinon.fake();
@@ -1123,9 +1115,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
 
       // Expect to see all the input data we supplied in the Approved Item
       // returned by the mutation
-      expect(result.data?.createApprovedCuratedCorpusItem).to.deep.include(
-        input
-      );
+      expect(result.data?.createApprovedCorpusItem).to.deep.include(input);
 
       // Check that the ADD_ITEM event was fired successfully:
       // 1 - Event was fired once!
@@ -1137,7 +1127,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       // 3- Event has the right entity passed to it.
       expect(
         await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(result.data?.createApprovedCuratedCorpusItem.externalId);
+      ).to.equal(result.data?.createApprovedCorpusItem.externalId);
 
       await server.stop();
     });
@@ -1243,7 +1233,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
 
       // On success, mutation should return the deleted approved item.
       // Let's verify the id.
-      expect(result.data?.rejectApprovedCuratedCorpusItem.externalId).to.equal(
+      expect(result.data?.rejectApprovedCorpusItem.externalId).to.equal(
         item.externalId
       );
 

--- a/src/admin/resolvers/mutations/ApprovedItem.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.ts
@@ -15,8 +15,8 @@ import {
 } from '../../../events/types';
 import { uploadImageToS3, uploadImageToS3FromUrl } from '../../aws/upload';
 import {
-  ImportApprovedCuratedCorpusItemInput,
-  ImportApprovedCuratedCorpusItemPayload,
+  ImportApprovedCorpusItemInput,
+  ImportApprovedCorpusItemPayload,
 } from '../types';
 import {
   ACCESS_DENIED_ERROR,
@@ -266,9 +266,9 @@ export async function uploadApprovedItemImage(
  */
 export async function importApprovedItem(
   parent,
-  { data }: { data: ImportApprovedCuratedCorpusItemInput },
+  { data }: { data: ImportApprovedCorpusItemInput },
   context: IContext
-): Promise<ImportApprovedCuratedCorpusItemPayload> {
+): Promise<ImportApprovedCorpusItemPayload> {
   // Check if user is authorized to import an item
   if (!context.authenticatedUser.canWriteToCorpus()) {
     throw new AuthenticationError(ACCESS_DENIED_ERROR);
@@ -335,12 +335,12 @@ export async function importApprovedItem(
 }
 
 /**
- * Transform GraphQL ImportApprovedCuratedCorpusItemInput to ImportApprovedItemInput
+ * Transform GraphQL ImportApprovedCorpusItemInput to ImportApprovedItemInput
  * for the database
  * @param data
  */
 function toDbApprovedItemInput(
-  data: ImportApprovedCuratedCorpusItemInput
+  data: ImportApprovedCorpusItemInput
 ): ImportApprovedItemInput {
   return {
     title: data.title,
@@ -362,12 +362,12 @@ function toDbApprovedItemInput(
 }
 
 /**
- * Transforms GraphQL ImportApprovedCuratedCorpusItemInput with approvedItemId
+ * Transforms GraphQL ImportApprovedCorpusItemInput with approvedItemId
  * to ImportScheduledItemInput for the database
  * @param data
  */
 function toDbScheduledItemInput(
-  data: ImportApprovedCuratedCorpusItemInput & { approvedItemId: number }
+  data: ImportApprovedCorpusItemInput & { approvedItemId: number }
 ): ImportScheduledItemInput {
   return {
     approvedItemId: data.approvedItemId,

--- a/src/admin/resolvers/mutations/RejectedItem.integration.ts
+++ b/src/admin/resolvers/mutations/RejectedItem.integration.ts
@@ -36,7 +36,7 @@ describe('mutations: RejectedItem', () => {
     await clearDb(db);
   });
 
-  describe('createRejectedCuratedCorpusItem mutation', () => {
+  describe('createRejectedCorpusItem mutation', () => {
     // a standard set of inputs for this mutation
     let input: CreateRejectedItemInput;
 
@@ -68,11 +68,9 @@ describe('mutations: RejectedItem', () => {
 
       // Expect to see all the input data we supplied in the Approved Item
       // returned by the mutation
-      expect(result.data?.createRejectedCuratedCorpusItem).to.deep.include(
-        input
-      );
+      expect(result.data?.createRejectedCorpusItem).to.deep.include(input);
       // Expect to see the SSO username in the `createdBy` field
-      expect(result.data?.createRejectedCuratedCorpusItem.createdBy).to.equal(
+      expect(result.data?.createRejectedCorpusItem.createdBy).to.equal(
         headers.username
       );
 
@@ -86,7 +84,7 @@ describe('mutations: RejectedItem', () => {
       // 3- Event has the right entity passed to it.
       expect(
         await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(result.data?.createRejectedCuratedCorpusItem.externalId);
+      ).to.equal(result.data?.createRejectedCorpusItem.externalId);
     });
 
     it('creates a rejected item without a prospectId', async () => {
@@ -107,11 +105,11 @@ describe('mutations: RejectedItem', () => {
 
       // Expect to see all the input data we supplied in the Approved Item
       // returned by the mutation
-      expect(result.data?.createRejectedCuratedCorpusItem).to.deep.include(
+      expect(result.data?.createRejectedCorpusItem).to.deep.include(
         inputWithoutProspectId
       );
       // Expect to see the SSO username in the `createdBy` field
-      expect(result.data?.createRejectedCuratedCorpusItem.createdBy).to.equal(
+      expect(result.data?.createRejectedCorpusItem.createdBy).to.equal(
         headers.username
       );
 
@@ -125,7 +123,7 @@ describe('mutations: RejectedItem', () => {
       // 3- Event has the right entity passed to it.
       expect(
         await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(result.data?.createRejectedCuratedCorpusItem.externalId);
+      ).to.equal(result.data?.createRejectedCorpusItem.externalId);
     });
 
     it('should create a rejected item if the user has access to at least one of the scheduled surfaces', async () => {
@@ -146,9 +144,7 @@ describe('mutations: RejectedItem', () => {
 
       // Expect to see all the input data we supplied in the Approved Item
       // returned by the mutation
-      expect(result.data?.createRejectedCuratedCorpusItem).to.deep.include(
-        input
-      );
+      expect(result.data?.createRejectedCorpusItem).to.deep.include(input);
 
       await server.stop();
     });

--- a/src/admin/resolvers/mutations/ScheduledItem.integration.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.integration.ts
@@ -42,7 +42,7 @@ describe('mutations: ScheduledItem', () => {
     await clearDb(db);
   });
 
-  describe('createScheduledCuratedCorpusItem mutation', () => {
+  describe('createScheduledCorpusItem mutation', () => {
     it('should fail on invalid Scheduled Surface GUID', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
@@ -177,7 +177,7 @@ describe('mutations: ScheduledItem', () => {
         variables: { data: input },
       });
 
-      const scheduledItem = data?.createScheduledCuratedCorpusItem;
+      const scheduledItem = data?.createScheduledCorpusItem;
 
       // Expect these fields to return valid values
       expect(scheduledItem.externalId).to.not.be.null;
@@ -317,7 +317,7 @@ describe('mutations: ScheduledItem', () => {
     });
   });
 
-  describe('deleteScheduledCuratedCorpusItem mutation', () => {
+  describe('deleteScheduledCorpusItem mutation', () => {
     it('should fail on invalid external ID', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
@@ -376,7 +376,7 @@ describe('mutations: ScheduledItem', () => {
       // ApprovedItem), so until there is a query to retrieve the scheduled item
       // of the right shape (if it's ever implemented), laborious property-by-property
       // comparison is the go.
-      const returnedItem = data?.deleteScheduledCuratedCorpusItem;
+      const returnedItem = data?.deleteScheduledCorpusItem;
       expect(returnedItem.externalId).to.equal(scheduledItem.externalId);
       expect(returnedItem.createdBy).to.equal(scheduledItem.createdBy);
       expect(returnedItem.updatedBy).to.equal(headers.username);
@@ -516,7 +516,7 @@ describe('mutations: ScheduledItem', () => {
     });
   });
 
-  describe('rescheduleScheduledCuratedCorpusItem mutation', () => {
+  describe('rescheduleScheduledCorpusItem mutation', () => {
     it('should fail on invalid external ID', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
@@ -577,7 +577,7 @@ describe('mutations: ScheduledItem', () => {
       // ApprovedItem), so until there is a query to retrieve the scheduled item
       // of the right shape (if it's ever implemented), laborious property-by-property
       // comparison is the go.
-      const returnedItem = data?.rescheduleScheduledCuratedCorpusItem;
+      const returnedItem = data?.rescheduleScheduledCorpusItem;
       expect(returnedItem.externalId).to.equal(scheduledItem.externalId);
       expect(returnedItem.createdBy).to.equal(scheduledItem.createdBy);
       expect(returnedItem.updatedBy).to.equal(headers.username);

--- a/src/admin/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/admin/resolvers/mutations/sample-mutations.gql.ts
@@ -10,8 +10,8 @@ import {
  * Curation Admin Tools Frontend and this repository's integration tests.
  */
 export const CREATE_APPROVED_ITEM = gql`
-  mutation createApprovedItem($data: CreateApprovedCuratedCorpusItemInput!) {
-    createApprovedCuratedCorpusItem(data: $data) {
+  mutation createApprovedItem($data: CreateApprovedCorpusItemInput!) {
+    createApprovedCorpusItem(data: $data) {
       ...CuratedItemData
     }
   }
@@ -19,10 +19,8 @@ export const CREATE_APPROVED_ITEM = gql`
 `;
 
 export const UPDATE_APPROVED_ITEM = gql`
-  mutation updateApprovedCuratedCorpusItem(
-    $data: UpdateApprovedCuratedCorpusItemInput!
-  ) {
-    updateApprovedCuratedCorpusItem(data: $data) {
+  mutation updateApprovedCorpusItem($data: UpdateApprovedCorpusItemInput!) {
+    updateApprovedCorpusItem(data: $data) {
       ...CuratedItemData
     }
   }
@@ -30,8 +28,8 @@ export const UPDATE_APPROVED_ITEM = gql`
 `;
 
 export const REJECT_APPROVED_ITEM = gql`
-  mutation rejectApprovedItem($data: RejectApprovedCuratedCorpusItemInput!) {
-    rejectApprovedCuratedCorpusItem(data: $data) {
+  mutation rejectApprovedItem($data: RejectApprovedCorpusItemInput!) {
+    rejectApprovedCorpusItem(data: $data) {
       ...CuratedItemData
     }
   }
@@ -39,8 +37,8 @@ export const REJECT_APPROVED_ITEM = gql`
 `;
 
 export const CREATE_REJECTED_ITEM = gql`
-  mutation createRejectedItem($data: CreateRejectedCuratedCorpusItemInput!) {
-    createRejectedCuratedCorpusItem(data: $data) {
+  mutation createRejectedItem($data: CreateRejectedCorpusItemInput!) {
+    createRejectedCorpusItem(data: $data) {
       ...RejectedItemData
     }
   }
@@ -48,8 +46,8 @@ export const CREATE_REJECTED_ITEM = gql`
 `;
 
 export const CREATE_SCHEDULED_ITEM = gql`
-  mutation createScheduledItem($data: CreateScheduledCuratedCorpusItemInput!) {
-    createScheduledCuratedCorpusItem(data: $data) {
+  mutation createScheduledItem($data: CreateScheduledCorpusItemInput!) {
+    createScheduledCorpusItem(data: $data) {
       ...ScheduledItemData
     }
   }
@@ -57,8 +55,8 @@ export const CREATE_SCHEDULED_ITEM = gql`
 `;
 
 export const DELETE_SCHEDULED_ITEM = gql`
-  mutation deleteScheduledItem($data: DeleteScheduledCuratedCorpusItemInput!) {
-    deleteScheduledCuratedCorpusItem(data: $data) {
+  mutation deleteScheduledItem($data: DeleteScheduledCorpusItemInput!) {
+    deleteScheduledCorpusItem(data: $data) {
       ...ScheduledItemData
     }
   }
@@ -66,10 +64,8 @@ export const DELETE_SCHEDULED_ITEM = gql`
 `;
 
 export const RESCHEDULE_SCHEDULED_ITEM = gql`
-  mutation rescheduleScheduledItem(
-    $data: RescheduleScheduledCuratedCorpusItemInput!
-  ) {
-    rescheduleScheduledCuratedCorpusItem(data: $data) {
+  mutation rescheduleScheduledItem($data: RescheduleScheduledCorpusItemInput!) {
+    rescheduleScheduledCorpusItem(data: $data) {
       ...ScheduledItemData
     }
   }
@@ -77,16 +73,16 @@ export const RESCHEDULE_SCHEDULED_ITEM = gql`
 `;
 
 export const UPLOAD_APPROVED_ITEM_IMAGE = gql`
-  mutation uploadApprovedCuratedCorpusItemImage($image: Upload!) {
-    uploadApprovedCuratedCorpusItemImage(data: $image) {
+  mutation uploadApprovedCorpusItemImage($image: Upload!) {
+    uploadApprovedCorpusItemImage(data: $image) {
       url
     }
   }
 `;
 
 export const IMPORT_APPROVED_ITEM = gql`
-  mutation importApprovedItem($data: ImportApprovedCuratedCorpusItemInput!) {
-    importApprovedCuratedCorpusItem(data: $data) {
+  mutation importApprovedItem($data: ImportApprovedCorpusItemInput!) {
+    importApprovedCorpusItem(data: $data) {
       approvedItem {
         ...CuratedItemData
       }

--- a/src/admin/resolvers/queries/ApprovedItem.auth.integration.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.auth.integration.ts
@@ -12,7 +12,7 @@ import {
   GET_APPROVED_ITEM_BY_URL,
 } from './sample-queries.gql';
 
-describe('queries: ApprovedCuratedCorpusItem - authentication', () => {
+describe('queries: ApprovedCorpusItem - authentication', () => {
   beforeAll(async () => {
     // clear out db to start fresh
     await clearDb(db);
@@ -50,7 +50,7 @@ describe('queries: ApprovedCuratedCorpusItem - authentication', () => {
     await db.$disconnect();
   });
 
-  describe('getApprovedCuratedCorpusItems query', () => {
+  describe('getApprovedCorpusItems query', () => {
     it('should get all items when user has read-only access', async () => {
       // Set up auth headers with read-only access
       const headers = {
@@ -70,9 +70,7 @@ describe('queries: ApprovedCuratedCorpusItem - authentication', () => {
       expect(result.data).not.to.be.null;
 
       // should return all 3 items
-      expect(result.data?.getApprovedCuratedCorpusItems.edges).to.have.length(
-        3
-      );
+      expect(result.data?.getApprovedCorpusItems.edges).to.have.length(3);
 
       await server.stop();
     });
@@ -96,9 +94,7 @@ describe('queries: ApprovedCuratedCorpusItem - authentication', () => {
       expect(result.data).not.to.be.null;
 
       // should return all 3 items
-      expect(result.data?.getApprovedCuratedCorpusItems.edges).to.have.length(
-        3
-      );
+      expect(result.data?.getApprovedCorpusItems.edges).to.have.length(3);
 
       await server.stop();
     });
@@ -154,7 +150,7 @@ describe('queries: ApprovedCuratedCorpusItem - authentication', () => {
     });
   });
 
-  describe('getApprovedCuratedCorpusItemByUrl query', () => {
+  describe('getApprovedCorpusItemByUrl query', () => {
     it('should get item when user has read-only access', async () => {
       // Set up auth headers with read-only access
       const headers = {
@@ -221,7 +217,7 @@ describe('queries: ApprovedCuratedCorpusItem - authentication', () => {
         },
       });
 
-      expect(result.data?.getApprovedCuratedCorpusItemByUrl).to.be.null;
+      expect(result.data?.getApprovedCorpusItemByUrl).to.be.null;
 
       expect(result.errors).not.to.be.undefined;
       // check if the error we get is access denied error
@@ -249,7 +245,7 @@ describe('queries: ApprovedCuratedCorpusItem - authentication', () => {
         },
       });
 
-      expect(result.data?.getApprovedCuratedCorpusItemByUrl).to.be.null;
+      expect(result.data?.getApprovedCorpusItemByUrl).to.be.null;
 
       expect(result.errors).not.to.be.undefined;
       // check if the error we get is access denied error

--- a/src/admin/resolvers/queries/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.integration.ts
@@ -14,7 +14,7 @@ import {
 import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
 import { MozillaAccessGroup } from '../../../shared/types';
 
-describe('queries: ApprovedCuratedCorpusItem', () => {
+describe('queries: ApprovedCorpusItem', () => {
   // adding headers with groups that grant full access
   const headers = {
     name: 'Test User',
@@ -37,7 +37,7 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
     await server.stop();
   });
 
-  describe('getApprovedCuratedCorpusItems query', () => {
+  describe('getApprovedCorpusItems query', () => {
     beforeAll(async () => {
       // Create some items
       const stories = [
@@ -118,12 +118,12 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
         },
       });
 
-      expect(data?.getApprovedCuratedCorpusItems.edges).to.have.length(10);
-      expect(data?.getApprovedCuratedCorpusItems.totalCount).to.equal(10);
+      expect(data?.getApprovedCorpusItems.edges).to.have.length(10);
+      expect(data?.getApprovedCorpusItems.totalCount).to.equal(10);
 
       // Check default sorting - createdAt.DESC
-      const firstItem = data?.getApprovedCuratedCorpusItems.edges[0].node;
-      const secondItem = data?.getApprovedCuratedCorpusItems.edges[1].node;
+      const firstItem = data?.getApprovedCorpusItems.edges[0].node;
+      const secondItem = data?.getApprovedCorpusItems.edges[1].node;
       expect(firstItem.createdAt > secondItem.createdAt).to.be.true;
     });
 
@@ -135,7 +135,7 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
         },
       });
 
-      const firstItem = data?.getApprovedCuratedCorpusItems.edges[0].node;
+      const firstItem = data?.getApprovedCorpusItems.edges[0].node;
       // The important thing to test here is that the query returns all of these
       // properties without falling over, and not that they hold any specific value.
       expect(firstItem.externalId).to.be.not.undefined;
@@ -163,7 +163,7 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
       });
 
       // We expect to get two results back
-      expect(data?.getApprovedCuratedCorpusItems.edges).to.have.length(2);
+      expect(data?.getApprovedCorpusItems.edges).to.have.length(2);
     });
 
     it('should return a PageInfo object', async () => {
@@ -174,7 +174,7 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
         },
       });
 
-      const pageInfo = data?.getApprovedCuratedCorpusItems.pageInfo;
+      const pageInfo = data?.getApprovedCorpusItems.pageInfo;
       expect(pageInfo.hasNextPage).to.equal(true);
       expect(pageInfo.hasPreviousPage).to.equal(false);
       expect(pageInfo.startCursor).to.be.a('string');
@@ -189,7 +189,7 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
         },
       });
 
-      const cursor = data?.getApprovedCuratedCorpusItems.edges[3].cursor;
+      const cursor = data?.getApprovedCorpusItems.edges[3].cursor;
 
       const { data: nextPageData } = await server.executeOperation({
         query: GET_APPROVED_ITEMS,
@@ -198,7 +198,7 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
         },
       });
 
-      expect(nextPageData?.getApprovedCuratedCorpusItems.edges)
+      expect(nextPageData?.getApprovedCorpusItems.edges)
         .to.be.an('array')
         .that.does.not.contain({ cursor });
     });
@@ -211,7 +211,7 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
         },
       });
 
-      const cursor = data?.getApprovedCuratedCorpusItems.edges[0].cursor;
+      const cursor = data?.getApprovedCorpusItems.edges[0].cursor;
 
       const { data: prevPageData } = await server.executeOperation({
         query: GET_APPROVED_ITEMS,
@@ -220,7 +220,7 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
         },
       });
 
-      expect(prevPageData?.getApprovedCuratedCorpusItems.edges)
+      expect(prevPageData?.getApprovedCorpusItems.edges)
         .to.be.an('array')
         .that.does.not.contain({ cursor });
     });
@@ -234,9 +234,9 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
       });
 
       // we only have three stories in German set up before each test
-      expect(data?.getApprovedCuratedCorpusItems.edges).to.have.length(3);
+      expect(data?.getApprovedCorpusItems.edges).to.have.length(3);
       // make sure the total count is not _all_ results, i.e. 10, but only three
-      expect(data?.getApprovedCuratedCorpusItems.totalCount).to.equal(3);
+      expect(data?.getApprovedCorpusItems.totalCount).to.equal(3);
     });
 
     it('should filter by story title', async () => {
@@ -248,9 +248,9 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
       });
 
       // we only have one story with "Zombies" in the title
-      expect(data?.getApprovedCuratedCorpusItems.edges).to.have.length(1);
+      expect(data?.getApprovedCorpusItems.edges).to.have.length(1);
       // make sure total results value is correct
-      expect(data?.getApprovedCuratedCorpusItems.totalCount).to.equal(1);
+      expect(data?.getApprovedCorpusItems.totalCount).to.equal(1);
     });
 
     it('should filter by topic', async () => {
@@ -262,10 +262,10 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
       });
 
       // we only have two stories categorised as "Technology"
-      expect(data?.getApprovedCuratedCorpusItems.edges).to.have.length(2);
+      expect(data?.getApprovedCorpusItems.edges).to.have.length(2);
 
       // make sure total results value is correct
-      expect(data?.getApprovedCuratedCorpusItems.totalCount).to.equal(2);
+      expect(data?.getApprovedCorpusItems.totalCount).to.equal(2);
     });
 
     it('should filter by curated status', async () => {
@@ -277,9 +277,9 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
       });
 
       // expect to see six stories added to the corpus as second-tier recommendations
-      expect(data?.getApprovedCuratedCorpusItems.edges).to.have.length(6);
+      expect(data?.getApprovedCorpusItems.edges).to.have.length(6);
       // make sure total results value is correct
-      expect(data?.getApprovedCuratedCorpusItems.totalCount).to.equal(6);
+      expect(data?.getApprovedCorpusItems.totalCount).to.equal(6);
     });
 
     it('should filter by story URL', async () => {
@@ -291,9 +291,9 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
       });
 
       // expect to see just the one story with the above domain
-      expect(data?.getApprovedCuratedCorpusItems.edges).to.have.length(1);
+      expect(data?.getApprovedCorpusItems.edges).to.have.length(1);
       // make sure total results value is correct
-      expect(data?.getApprovedCuratedCorpusItems.totalCount).to.equal(1);
+      expect(data?.getApprovedCorpusItems.totalCount).to.equal(1);
     });
 
     it('should filter by several parameters', async () => {
@@ -311,13 +311,13 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
       });
 
       // expect to see just the one story
-      expect(data?.getApprovedCuratedCorpusItems.edges).to.have.length(1);
+      expect(data?.getApprovedCorpusItems.edges).to.have.length(1);
       // make sure total results value is correct
-      expect(data?.getApprovedCuratedCorpusItems.totalCount).to.equal(1);
+      expect(data?.getApprovedCorpusItems.totalCount).to.equal(1);
     });
   });
 
-  describe('getApprovedCuratedCorpusItemByUrl query', () => {
+  describe('getApprovedCorpusItemByUrl query', () => {
     beforeAll(async () => {
       // Create a few items with known URLs.
       const storyInput = [
@@ -350,7 +350,7 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
         },
       });
 
-      const item = result.data?.getApprovedCuratedCorpusItemByUrl;
+      const item = result.data?.getApprovedCorpusItemByUrl;
 
       // Is this really the item we wanted to retrieve?
       expect(item.url).to.equal(inputUrl);
@@ -382,10 +382,10 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
         },
       });
 
-      expect(result.data).to.have.property('getApprovedCuratedCorpusItemByUrl');
+      expect(result.data).to.have.property('getApprovedCorpusItemByUrl');
 
       // There should be no data returned
-      expect(result.data?.getApprovedCuratedCorpusItemByUrl).to.be.null;
+      expect(result.data?.getApprovedCorpusItemByUrl).to.be.null;
 
       // There should be no errors
       expect(result.errors).to.be.undefined;
@@ -437,7 +437,7 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
         variables: {
           representations: [
             {
-              __typename: 'ApprovedCuratedCorpusItem',
+              __typename: 'ApprovedCorpusItem',
               url: 'https://www.test2.com/story-three',
             },
           ],
@@ -456,19 +456,19 @@ describe('queries: ApprovedCuratedCorpusItem', () => {
         variables: {
           representations: [
             {
-              __typename: 'ApprovedCuratedCorpusItem',
+              __typename: 'ApprovedCorpusItem',
               url: 'https://www.test2.com/story-seven',
             },
             {
-              __typename: 'ApprovedCuratedCorpusItem',
+              __typename: 'ApprovedCorpusItem',
               url: 'https://www.test2.com/story-three',
             },
             {
-              __typename: 'ApprovedCuratedCorpusItem',
+              __typename: 'ApprovedCorpusItem',
               url: 'https://www.sample-domain.com/what-zombies-can-teach-you-graphql',
             },
             {
-              __typename: 'ApprovedCuratedCorpusItem',
+              __typename: 'ApprovedCorpusItem',
               url: 'https://www.test2.com/story-two',
             },
           ],

--- a/src/admin/resolvers/queries/RejectedItem.auth.integration.ts
+++ b/src/admin/resolvers/queries/RejectedItem.auth.integration.ts
@@ -8,10 +8,10 @@ import { ACCESS_DENIED_ERROR, MozillaAccessGroup } from '../../../shared/types';
 import { GET_REJECTED_ITEMS } from './sample-queries.gql';
 import { expect } from 'chai';
 
-describe('queries: RejectedCuratedCorpusItem (authentication)', () => {
-  // A few sample Rejected Curated Corpus items - we don't need a lot of these
+describe('queries: RejectedCorpusItem (authentication)', () => {
+  // A few sample Rejected Corpus items - we don't need a lot of these
   // for auth checks
-  const rejectedCuratedCorpusItems = [
+  const rejectedCorpusItems = [
     {
       title: '10 Unforgivable Sins Of PHP',
     },
@@ -39,7 +39,7 @@ describe('queries: RejectedCuratedCorpusItem (authentication)', () => {
   beforeAll(async () => {
     await clearDb(db);
 
-    for (const item of rejectedCuratedCorpusItems) {
+    for (const item of rejectedCorpusItems) {
       await createRejectedCuratedCorpusItemHelper(db, item);
     }
   });
@@ -48,7 +48,7 @@ describe('queries: RejectedCuratedCorpusItem (authentication)', () => {
     await db.$disconnect();
   });
 
-  describe('getRejectedCuratedCorpusItem query', () => {
+  describe('getRejectedCorpusItem query', () => {
     it('should get all items when user has read-only access', async () => {
       // Set up auth headers with read-only access
       headers = {
@@ -67,9 +67,7 @@ describe('queries: RejectedCuratedCorpusItem (authentication)', () => {
       expect(result.data).not.to.be.null;
 
       // should return all four items - the entire corpus should be accessible
-      expect(result.data?.getRejectedCuratedCorpusItems.edges).to.have.length(
-        4
-      );
+      expect(result.data?.getRejectedCorpusItems.edges).to.have.length(4);
 
       await server.stop();
     });
@@ -92,9 +90,7 @@ describe('queries: RejectedCuratedCorpusItem (authentication)', () => {
       expect(result.data).not.to.be.null;
 
       // should return all four items - the entire corpus should be accessible
-      expect(result.data?.getRejectedCuratedCorpusItems.edges).to.have.length(
-        4
-      );
+      expect(result.data?.getRejectedCorpusItems.edges).to.have.length(4);
 
       await server.stop();
     });

--- a/src/admin/resolvers/queries/RejectedItem.integration.ts
+++ b/src/admin/resolvers/queries/RejectedItem.integration.ts
@@ -10,7 +10,7 @@ import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmi
 import { MozillaAccessGroup } from '../../../shared/types';
 import { getServerWithMockedHeaders } from '../../../test/helpers/getServerWithMockedHeaders';
 
-describe('queries: RejectedCuratedCorpusItem', () => {
+describe('queries: RejectedCorpusItem', () => {
   const headers = {
     name: 'Test User',
     username: 'test.user@test.com',
@@ -32,7 +32,7 @@ describe('queries: RejectedCuratedCorpusItem', () => {
     await server.stop();
   });
 
-  describe('getRejectedCuratedCorpusItem query', () => {
+  describe('getRejectedCorpusItem query', () => {
     // Fake sample Rejected Curated Corpus items
     const rejectedCuratedCorpusItems = [
       {
@@ -95,10 +95,10 @@ describe('queries: RejectedCuratedCorpusItem', () => {
         },
       });
 
-      expect(data?.getRejectedCuratedCorpusItems.edges).to.have.length(
+      expect(data?.getRejectedCorpusItems.edges).to.have.length(
         rejectedCuratedCorpusItems.length
       );
-      expect(data?.getRejectedCuratedCorpusItems.totalCount).to.equal(
+      expect(data?.getRejectedCorpusItems.totalCount).to.equal(
         rejectedCuratedCorpusItems.length
       );
     });
@@ -108,8 +108,8 @@ describe('queries: RejectedCuratedCorpusItem', () => {
         query: GET_REJECTED_ITEMS,
       });
 
-      const firstItem = data?.getRejectedCuratedCorpusItems.edges[0].node;
-      const secondItem = data?.getRejectedCuratedCorpusItems.edges[1].node;
+      const firstItem = data?.getRejectedCorpusItems.edges[0].node;
+      const secondItem = data?.getRejectedCorpusItems.edges[1].node;
 
       expect(firstItem.createdAt).to.be.greaterThan(secondItem.createdAt);
     });
@@ -123,7 +123,7 @@ describe('queries: RejectedCuratedCorpusItem', () => {
       });
 
       const firstItem: dbRejectedCuratedCorpusItem =
-        data?.getRejectedCuratedCorpusItems.edges[0].node;
+        data?.getRejectedCorpusItems.edges[0].node;
       // The important thing to test here is that the query returns all of these
       // properties without falling over, and not that they hold any specific value.
       expect(firstItem.externalId).to.be.not.undefined;
@@ -147,7 +147,7 @@ describe('queries: RejectedCuratedCorpusItem', () => {
       });
 
       // We expect to get two results back
-      expect(data?.getRejectedCuratedCorpusItems.edges).to.have.length(2);
+      expect(data?.getRejectedCorpusItems.edges).to.have.length(2);
     });
 
     it('should return a PageInfo object', async () => {
@@ -158,7 +158,7 @@ describe('queries: RejectedCuratedCorpusItem', () => {
         },
       });
 
-      const pageInfo = data?.getRejectedCuratedCorpusItems.pageInfo;
+      const pageInfo = data?.getRejectedCorpusItems.pageInfo;
       expect(pageInfo.hasNextPage).to.equal(true);
       expect(pageInfo.hasPreviousPage).to.equal(false);
       expect(pageInfo.startCursor).to.be.a('string');
@@ -172,7 +172,7 @@ describe('queries: RejectedCuratedCorpusItem', () => {
         },
       });
 
-      const cursor = data?.getRejectedCuratedCorpusItems.edges[3].cursor;
+      const cursor = data?.getRejectedCorpusItems.edges[3].cursor;
 
       const { data: nextPageData } = await server.executeOperation({
         query: GET_REJECTED_ITEMS,
@@ -181,7 +181,7 @@ describe('queries: RejectedCuratedCorpusItem', () => {
         },
       });
 
-      expect(nextPageData?.getRejectedCuratedCorpusItems.edges)
+      expect(nextPageData?.getRejectedCorpusItems.edges)
         .to.be.an('array')
         .that.does.not.contain({ cursor });
     });
@@ -194,7 +194,7 @@ describe('queries: RejectedCuratedCorpusItem', () => {
         },
       });
 
-      const cursor = data?.getRejectedCuratedCorpusItems.edges[0].cursor;
+      const cursor = data?.getRejectedCorpusItems.edges[0].cursor;
 
       const { data: prevPageData } = await server.executeOperation({
         query: GET_REJECTED_ITEMS,
@@ -203,7 +203,7 @@ describe('queries: RejectedCuratedCorpusItem', () => {
         },
       });
 
-      expect(prevPageData?.getRejectedCuratedCorpusItems.edges)
+      expect(prevPageData?.getRejectedCorpusItems.edges)
         .to.be.an('array')
         .that.does.not.contain({ cursor });
     });
@@ -220,11 +220,11 @@ describe('queries: RejectedCuratedCorpusItem', () => {
         (item) => item.language === 'DE'
       );
       // we only have three stories in German set up before each test
-      expect(data?.getRejectedCuratedCorpusItems.edges).to.have.length(
+      expect(data?.getRejectedCorpusItems.edges).to.have.length(
         germanItems.length
       );
       // make sure the total count is not _all_ results, i.e. 10, but only three
-      expect(data?.getRejectedCuratedCorpusItems.totalCount).to.equal(
+      expect(data?.getRejectedCorpusItems.totalCount).to.equal(
         germanItems.length
       );
     });
@@ -238,9 +238,9 @@ describe('queries: RejectedCuratedCorpusItem', () => {
       });
 
       // we only have one story with "laravel" in the title
-      expect(data?.getRejectedCuratedCorpusItems.edges).to.have.length(1);
+      expect(data?.getRejectedCorpusItems.edges).to.have.length(1);
       // make sure total results value is correct
-      expect(data?.getRejectedCuratedCorpusItems.totalCount).to.equal(1);
+      expect(data?.getRejectedCorpusItems.totalCount).to.equal(1);
     });
 
     it('should filter by topic', async () => {
@@ -252,10 +252,10 @@ describe('queries: RejectedCuratedCorpusItem', () => {
       });
 
       // we only have two stories categorized as "Technology"
-      expect(data?.getRejectedCuratedCorpusItems.edges).to.have.length(2);
+      expect(data?.getRejectedCorpusItems.edges).to.have.length(2);
 
       // make sure total results value is correct
-      expect(data?.getRejectedCuratedCorpusItems.totalCount).to.equal(2);
+      expect(data?.getRejectedCorpusItems.totalCount).to.equal(2);
     });
 
     it('should filter by story URL', async () => {
@@ -267,9 +267,9 @@ describe('queries: RejectedCuratedCorpusItem', () => {
       });
 
       // expect to see just the one story with the above domain
-      expect(data?.getRejectedCuratedCorpusItems.edges).to.have.length(1);
+      expect(data?.getRejectedCorpusItems.edges).to.have.length(1);
       // make sure total results value is correct
-      expect(data?.getRejectedCuratedCorpusItems.totalCount).to.equal(1);
+      expect(data?.getRejectedCorpusItems.totalCount).to.equal(1);
     });
 
     it('should filter url, title, topic and language', async () => {
@@ -286,9 +286,9 @@ describe('queries: RejectedCuratedCorpusItem', () => {
       });
 
       // expect to see just the one story
-      expect(data?.getRejectedCuratedCorpusItems.edges).to.have.length(1);
+      expect(data?.getRejectedCorpusItems.edges).to.have.length(1);
       // make sure total results value is correct
-      expect(data?.getRejectedCuratedCorpusItems.totalCount).to.equal(1);
+      expect(data?.getRejectedCorpusItems.totalCount).to.equal(1);
     });
   });
 });

--- a/src/admin/resolvers/queries/ScheduledItem.auth.integration.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.auth.integration.ts
@@ -9,7 +9,7 @@ import { db } from '../../../test/admin-server';
 import { GET_SCHEDULED_ITEMS } from './sample-queries.gql';
 import { ACCESS_DENIED_ERROR, MozillaAccessGroup } from '../../../shared/types';
 
-describe('queries: ScheduledCuratedCorpusItem - authentication', () => {
+describe('queries: ScheduledCorpusItem - authentication', () => {
   beforeAll(async () => {
     await clearDb(db);
 
@@ -42,7 +42,7 @@ describe('queries: ScheduledCuratedCorpusItem - authentication', () => {
     await db.$disconnect();
   });
 
-  describe('getScheduledCuratedCorpusItems query', () => {
+  describe('getScheduledCorpusItems query', () => {
     it('should get all items when the user has read-only access', async () => {
       // adding headers with groups with read-only access
       const headers = {
@@ -67,7 +67,7 @@ describe('queries: ScheduledCuratedCorpusItem - authentication', () => {
       expect(result.errors).to.be.undefined;
       expect(result.data).not.to.be.null;
 
-      const resultArray = result.data?.getScheduledCuratedCorpusItems;
+      const resultArray = result.data?.getScheduledCorpusItems;
       expect(resultArray).to.have.lengthOf(2);
       expect(resultArray[0].totalCount).to.equal(10);
       expect(resultArray[0].items).to.have.lengthOf(10);
@@ -98,7 +98,7 @@ describe('queries: ScheduledCuratedCorpusItem - authentication', () => {
       expect(result.errors).to.be.undefined;
       expect(result.data).not.to.be.null;
 
-      const resultArray = result.data?.getScheduledCuratedCorpusItems;
+      const resultArray = result.data?.getScheduledCorpusItems;
       expect(resultArray).to.have.lengthOf(2);
       expect(resultArray[0].totalCount).to.equal(10);
       expect(resultArray[0].items).to.have.lengthOf(10);

--- a/src/admin/resolvers/queries/ScheduledItem.integration.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.integration.ts
@@ -10,7 +10,7 @@ import { GET_SCHEDULED_ITEMS } from './sample-queries.gql';
 import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
 import { MozillaAccessGroup } from '../../../shared/types';
 
-describe('queries: ScheduledCuratedCorpusItem', () => {
+describe('queries: ScheduledCorpusItem', () => {
   // adding headers with groups that grant full access
   const headers = {
     name: 'Test User',
@@ -33,7 +33,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
     await server.stop();
   });
 
-  describe('getScheduledCuratedCorpusItems query', () => {
+  describe('getScheduledCorpusItems query', () => {
     beforeAll(async () => {
       // Create some approved items and schedule them for a date in the future
       for (let i = 0; i < 5; i++) {
@@ -76,7 +76,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       expect(result.errors).to.be.undefined;
       expect(result.data).not.to.be.null;
 
-      const resultArray = result.data?.getScheduledCuratedCorpusItems;
+      const resultArray = result.data?.getScheduledCorpusItems;
       expect(resultArray).to.have.lengthOf(2);
       expect(resultArray[0].totalCount).to.equal(10);
       expect(resultArray[0].items).to.have.lengthOf(10);
@@ -97,7 +97,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       expect(result.errors).to.be.undefined;
       expect(result.data).not.to.be.null;
 
-      const resultArray = result.data?.getScheduledCuratedCorpusItems;
+      const resultArray = result.data?.getScheduledCorpusItems;
 
       // Check the first group of scheduled items
       expect(resultArray[0].collectionCount).not.to.be.null;
@@ -140,7 +140,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       expect(result.errors).to.be.undefined;
       expect(result.data).not.to.be.null;
 
-      const resultArray = result.data?.getScheduledCuratedCorpusItems;
+      const resultArray = result.data?.getScheduledCorpusItems;
 
       expect(resultArray[0].totalCount).to.equal(10);
       expect(resultArray[0].items).to.have.lengthOf(10);

--- a/src/admin/resolvers/queries/sample-queries.gql.ts
+++ b/src/admin/resolvers/queries/sample-queries.gql.ts
@@ -11,10 +11,10 @@ import {
  */
 export const GET_APPROVED_ITEMS = gql`
   query getApprovedItems(
-    $filters: ApprovedCuratedCorpusItemFilter
+    $filters: ApprovedCorpusItemFilter
     $pagination: PaginationInput
   ) {
-    getApprovedCuratedCorpusItems(filters: $filters, pagination: $pagination) {
+    getApprovedCorpusItems(filters: $filters, pagination: $pagination) {
       totalCount
       pageInfo {
         hasNextPage
@@ -35,10 +35,10 @@ export const GET_APPROVED_ITEMS = gql`
 
 export const GET_REJECTED_ITEMS = gql`
   query getRejectedItems(
-    $filters: RejectedCuratedCorpusItemFilter
+    $filters: RejectedCorpusItemFilter
     $pagination: PaginationInput
   ) {
-    getRejectedCuratedCorpusItems(filters: $filters, pagination: $pagination) {
+    getRejectedCorpusItems(filters: $filters, pagination: $pagination) {
       totalCount
       pageInfo {
         hasNextPage
@@ -58,8 +58,8 @@ export const GET_REJECTED_ITEMS = gql`
 `;
 
 export const GET_SCHEDULED_ITEMS = gql`
-  query getScheduledItems($filters: ScheduledCuratedCorpusItemsFilterInput!) {
-    getScheduledCuratedCorpusItems(filters: $filters) {
+  query getScheduledItems($filters: ScheduledCorpusItemsFilterInput!) {
+    getScheduledCorpusItems(filters: $filters) {
       totalCount
       collectionCount
       syndicatedCount
@@ -73,8 +73,8 @@ export const GET_SCHEDULED_ITEMS = gql`
 `;
 
 export const GET_APPROVED_ITEM_BY_URL = gql`
-  query getApprovedCuratedCorpusItemByUrl($url: String!) {
-    getApprovedCuratedCorpusItemByUrl(url: $url) {
+  query getApprovedCorpusItemByUrl($url: String!) {
+    getApprovedCorpusItemByUrl(url: $url) {
       ...CuratedItemData
     }
   }
@@ -95,7 +95,7 @@ export const GET_SCHEDULED_SURFACES_FOR_USER = gql`
 export const APPROVED_ITEM_REFERENCE_RESOLVER = gql`
   query ($representations: [_Any!]!) {
     _entities(representations: $representations) {
-      ... on ApprovedCuratedCorpusItem {
+      ... on ApprovedCorpusItem {
         ...CuratedItemData
       }
     }

--- a/src/admin/resolvers/types.ts
+++ b/src/admin/resolvers/types.ts
@@ -1,12 +1,12 @@
 import { ApprovedItem, CuratedStatus, ScheduledItem } from '@prisma/client';
 import { CorpusItemSource } from '../../shared/types';
 
-export type ImportApprovedCuratedCorpusItemPayload = {
+export type ImportApprovedCorpusItemPayload = {
   approvedItem: ApprovedItem;
   scheduledItem: ScheduledItem;
 };
 
-export type ImportApprovedCuratedCorpusItemInput = {
+export type ImportApprovedCorpusItemInput = {
   url: string;
   title: string;
   excerpt: string;

--- a/src/shared/fragments.gql.ts
+++ b/src/shared/fragments.gql.ts
@@ -1,7 +1,7 @@
 import { gql } from 'apollo-server';
 
 export const CuratedItemData = gql`
-  fragment CuratedItemData on ApprovedCuratedCorpusItem {
+  fragment CuratedItemData on ApprovedCorpusItem {
     externalId
     prospectId
     title
@@ -24,7 +24,7 @@ export const CuratedItemData = gql`
 `;
 
 export const RejectedItemData = gql`
-  fragment RejectedItemData on RejectedCuratedCorpusItem {
+  fragment RejectedItemData on RejectedCorpusItem {
     externalId
     prospectId
     url
@@ -39,7 +39,7 @@ export const RejectedItemData = gql`
 `;
 
 export const ScheduledItemData = gql`
-  fragment ScheduledItemData on ScheduledCuratedCorpusItem {
+  fragment ScheduledItemData on ScheduledCorpusItem {
     externalId
     createdAt
     createdBy


### PR DESCRIPTION
**DO NOT MERGE** until accompanying tickets for the frontend and Prospect API are ready to go.

## Goal

Take `Curated` out of schema definitions as there's going to be only one Pocket corpus.

- Updated admin schema.

- Updated sample mutations and queries used for integration tests.

- Updated tests.

Note that Apollo check failures are expected. Once the PR is okay'd generally, these changes can be marked as safe and the checks re-run.

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1319