### PR TITLE
feat(events): Send remove-schedule-item event to event bridge

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -47,6 +47,7 @@ export default {
   },
   eventBridge: {
     addScheduledItemEventType: 'add-scheduled-item',
+    removeScheduledItemEventType: 'remove-scheduled-item',
     source: 'curation-migration-datasync',
   },
   sentry: {

--- a/src/events/eventBus/EventBusConfig.ts
+++ b/src/events/eventBus/EventBusConfig.ts
@@ -11,8 +11,18 @@ import { toUtcDateString } from '../../shared/utils';
 // Used to configure the default EventBusHandler class,
 // if a mapping is not passed to the constructor.
 export const eventBusConfig: EventHandlerCallbackMap = {
-  [ScheduledCorpusItemEventType.ADD_SCHEDULE]: (data: any) =>
-    payloadBuilders.scheduledItemEvent(data),
+  [ScheduledCorpusItemEventType.ADD_SCHEDULE]: (data: any) => {
+    return payloadBuilders.scheduledItemEvent(
+      config.eventBridge.addScheduledItemEventType,
+      data
+    );
+  },
+  [ScheduledCorpusItemEventType.REMOVE_SCHEDULE]: (data: any) => {
+    return payloadBuilders.scheduledItemEvent(
+      config.eventBridge.removeScheduledItemEventType,
+      data
+    );
+  },
 };
 
 // To add a new event handler, create a function that generates the
@@ -22,14 +32,16 @@ const payloadBuilders = {
   /**
    * Generate event payload to send to event bus when an approved item
    * is scheduled to go on New Tab
+   * @param eventType
    * @param data ScheduledCorpusItemPayload
    * @returns ScheduledItemEventBusPayload
    */
   scheduledItemEvent(
+    eventType: string,
     data: ScheduledCorpusItemPayload
   ): ScheduledItemEventBusPayload {
-    const eventPayload: ScheduledItemEventBusPayload = {
-      eventType: config.eventBridge.addScheduledItemEventType,
+    return {
+      eventType: eventType,
       scheduledItemId: data.scheduledCorpusItem.externalId,
       approvedItemId: data.scheduledCorpusItem.approvedItem.externalId,
       url: data.scheduledCorpusItem.approvedItem.url,
@@ -46,6 +58,5 @@ const payloadBuilders = {
       scheduledSurfaceGuid: data.scheduledCorpusItem.scheduledSurfaceGuid,
       scheduledDate: toUtcDateString(data.scheduledCorpusItem.scheduledDate),
     };
-    return eventPayload;
   },
 };


### PR DESCRIPTION
## Goal

Implement remove-schedule-item event

## I'd love feedback/perspectives on:
- 

## Implementation Decisions
- Reusing the payload transformer since the event body is always the same

## References

JIRA ticket:
* [INFRA-357]

Documentation:
* [Project doc](https://getpocket.atlassian.net/wiki/spaces/CP/pages/2648178701/Curation+Migration+DataSync+Events)


[INFRA-357]: https://getpocket.atlassian.net/browse/INFRA-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ