### PR TITLE
fix(shared data): [BACK-1381] Cannot add approved item with `CORONAVIRUS` topic

### DIFF
--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -69,6 +69,7 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
 export enum Topics {
   BUSINESS = 'BUSINESS',
   CAREER = 'CAREER',
+  CORONAVIRUS = 'CORONAVIRUS',
   EDUCATION = 'EDUCATION',
   ENTERTAINMENT = 'ENTERTAINMENT',
   FOOD = 'FOOD',


### PR DESCRIPTION
## Goal

Let the curators save/edit items with `CORONAVIRUS` as the topic. While present in the GraphQL schema, for some reason it was overlooked when a TypeScript enum was set up with the same data.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1381