### PR TITLE
feat(events): update events

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -48,6 +48,8 @@ export default {
   eventBridge: {
     addScheduledItemEventType: 'add-scheduled-item',
     removeScheduledItemEventType: 'remove-scheduled-item',
+    updateScheduledItemEventType: 'update-scheduled-item',
+    updateApprovedItemEventType: 'update-approved-item',
     source: 'curation-migration-datasync',
   },
   sentry: {

--- a/src/events/eventBus/EventBusConfig.ts
+++ b/src/events/eventBus/EventBusConfig.ts
@@ -1,4 +1,7 @@
 import {
+  ApprovedItemEventBusPayload,
+  ReviewedCorpusItemEventType,
+  ReviewedCorpusItemPayload,
   ScheduledCorpusItemEventType,
   ScheduledCorpusItemPayload,
   ScheduledItemEventBusPayload,
@@ -20,6 +23,18 @@ export const eventBusConfig: EventHandlerCallbackMap = {
   [ScheduledCorpusItemEventType.REMOVE_SCHEDULE]: (data: any) => {
     return payloadBuilders.scheduledItemEvent(
       config.eventBridge.removeScheduledItemEventType,
+      data
+    );
+  },
+  [ScheduledCorpusItemEventType.RESCHEDULE]: (data: any) => {
+    return payloadBuilders.scheduledItemEvent(
+      config.eventBridge.updateScheduledItemEventType,
+      data
+    );
+  },
+  [ReviewedCorpusItemEventType.UPDATE_ITEM]: (data: any) => {
+    return payloadBuilders.approvedItemEvent(
+      config.eventBridge.updateApprovedItemEventType,
       data
     );
   },
@@ -57,6 +72,32 @@ const payloadBuilders = {
       updatedAt: data.scheduledCorpusItem.updatedAt.toUTCString(),
       scheduledSurfaceGuid: data.scheduledCorpusItem.scheduledSurfaceGuid,
       scheduledDate: toUtcDateString(data.scheduledCorpusItem.scheduledDate),
+    };
+  },
+  approvedItemEvent(
+    eventType: string,
+    data: ReviewedCorpusItemPayload
+  ): ApprovedItemEventBusPayload {
+    // The nullish coalesce and checking for properties are due to
+    // union type in ReviewedCorpusItemPayload
+    const item = data.reviewedCorpusItem;
+    return {
+      eventType: eventType,
+      approvedItemId: item.externalId,
+      url: item.url,
+      title: item.title ?? undefined,
+      excerpt: 'excerpt' in item ? item.excerpt : undefined,
+      language: 'language' in item ? item.language ?? undefined : undefined,
+      publisher: 'publisher' in item ? item.publisher ?? undefined : undefined,
+      imageUrl: 'imageUrl' in item ? item.imageUrl : undefined,
+      topic: item.topic,
+      isSyndicated: 'isSyndicated' in item ? item.isSyndicated : undefined,
+      createdAt: item.createdAt.toUTCString(),
+      createdBy: item.createdBy,
+      updatedAt:
+        'updatedAt' in item
+          ? item.updatedAt.toUTCString()
+          : new Date().toUTCString(),
     };
   },
 };

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -58,3 +58,23 @@ export type ScheduledItemEventBusPayload = BaseEventBusPayload &
     createdAt: string; // UTC timestamp string
     updatedAt: string; // UTC timestamp string
   };
+
+export type ApprovedItemEventBusPayload = BaseEventBusPayload &
+  Partial<
+    Pick<
+      ApprovedItem,
+      | 'url'
+      | 'title'
+      | 'excerpt'
+      | 'language'
+      | 'publisher'
+      | 'imageUrl'
+      | 'topic'
+      | 'isSyndicated'
+      | 'createdBy'
+    >
+  > & {
+    approvedItemId: string; // externalId of ApprovedItem
+    createdAt?: string; // UTC timestamp string
+    updatedAt: string; // UTC timestamp string;
+  };


### PR DESCRIPTION
## Goal

Send update events for scheduled + approved items.

Since the application emits two different kinds of events for updating (updating the scheduled item's date/surface vs. the underlying item's fields), we handle them as separate events for event bridge.

Since the legacy system does not have a concept of an approved item that isn't scheduled, It is up to the event subscriber to determine whether it needs to process changes to an approved item.

## I'd love feedback/perspectives on:
- all

## Implementation Decisions
- Not refactoring the types, although at this time only approved items (and not a union of approved + rejected) are included as a payload on the update event

## References

JIRA ticket:
* [INFRA-356]

Documentation:
* [Project doc](https://getpocket.atlassian.net/wiki/spaces/CP/pages/2648178701/Curation+Migration+DataSync+Events)


[INFRA-356]: https://getpocket.atlassian.net/browse/INFRA-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ