### PR TITLE
fix(images): use pocket-image-cache when possible

### DIFF
--- a/src/admin/aws/upload.integration.ts
+++ b/src/admin/aws/upload.integration.ts
@@ -41,7 +41,7 @@ describe('Upload', () => {
   });
 
   it('uploads an image to s3 using the url', async () => {
-    nock('https://image.com')
+    nock('https://pocket-image-cache.com')
       .get('/dancing-in-the-air.jpeg')
       .replyWithFile(200, testFilePath, {
         'Content-Type': 'image/jpeg',
@@ -49,7 +49,7 @@ describe('Upload', () => {
 
     const upload = await uploadImageToS3FromUrl(
       s3,
-      'https://image.com/dancing-in-the-air.jpeg'
+      'https://pocket-image-cache.com/dancing-in-the-air.jpeg'
     );
 
     expectSuccessfulUpload(upload);

--- a/src/admin/aws/utils.ts
+++ b/src/admin/aws/utils.ts
@@ -2,7 +2,6 @@ import { FileUpload } from 'graphql-upload';
 import fetch from 'node-fetch';
 import mime from 'mime-types';
 import { InvalidImageUrl } from './errors';
-import * as https from 'https';
 
 /**
  * Fetch image from URL and transform into a GraphQL FileUpload object
@@ -10,13 +9,7 @@ import * as https from 'https';
  */
 export async function getFileUploadFromUrl(url: string): Promise<FileUpload> {
   try {
-    const httpsAgent = new https.Agent({
-      rejectUnauthorized: false,
-    });
-
-    const res = await fetch(url, {
-      agent: httpsAgent,
-    });
+    const res = await fetch(getPocketCacheUrl(url));
     const contentType = res.headers.get('content-type');
 
     checkValidImageContentType(contentType);
@@ -33,11 +26,25 @@ export async function getFileUploadFromUrl(url: string): Promise<FileUpload> {
 }
 
 /**
+ * Get pocket cache URL for a given URL
+ * @param url
+ */
+export function getPocketCacheUrl(url: string) {
+  if (url.includes('pocket-image-cache.com')) {
+    return url;
+  }
+
+  return `https://pocket-image-cache.com/x/filters:format(jpeg):quality(100):no_upscale():strip_exif()/${encodeURI(
+    url
+  )}`;
+}
+
+/**
  * Check content type header is a valid image content type.
  * Must begin with image
  * @param contentType
  */
-export function checkValidImageContentType(contentType): boolean {
+export function checkValidImageContentType(contentType: string): boolean {
   if (!contentType?.startsWith('image')) throw new Error();
 
   return true;

--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -870,7 +870,7 @@ describe('mutations: ApprovedItem', () => {
       title: 'Find Out How I Cured My Docker In 2 Days',
       excerpt: 'A short summary of what this story is about',
       status: CuratedStatus.RECOMMENDATION,
-      imageUrl: 'https://test.com/image.png',
+      imageUrl: 'https://pocket-image-cache.com/image.png',
       language: 'EN',
       publisher: 'Convective Cloud',
       topic: Topics.TECHNOLOGY,


### PR DESCRIPTION
## Goal
Use the pocket-image-cache service for all URLs except ones that are already pocket-image-cache URLs

## References

JIRA ticket: INFRA-400
