### PR TITLE
fix(federation): Temporarily restore ApprovedCuratedCorpusItem

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -119,6 +119,13 @@ type ScheduledSurface {
 }
 
 """
+Temp type to pacify federation checks
+"""
+type ApprovedCuratedCorpusItem @key(fields: "url") {
+    url: Url!
+}
+
+"""
 A prospective story that has been reviewed by the curators and saved to the corpus.
 """
 type ApprovedCorpusItem @key(fields: "url") {


### PR DESCRIPTION
## Goal

Even after a successful deployment of individual subgraphs related to dropping the word `Curated` from all entities, composition checks still fail. @kschelonka has suggested during our pairing that we should have duplicated the affected types instead - bringing `ApprovedCuratedCorpusItem` back temporarily should do the trick.

Follow-up to https://getpocket.atlassian.net/browse/BACK-1319