### PR TITLE
fix(importApprovedCorpusMutation): encode the image_url

### DIFF
--- a/src/admin/aws/utils.spec.ts
+++ b/src/admin/aws/utils.spec.ts
@@ -61,7 +61,7 @@ describe('Upload Utils', () => {
     expect(
       getPocketCacheUrl('https://sweet-potato.jpg?is_sweet=yes and no')
     ).toEqual(
-      'https://pocket-image-cache.com/x/filters:format(jpeg):quality(100):no_upscale():strip_exif()/https://sweet-potato.jpg?is_sweet=yes%20and%20no'
+      'https://pocket-image-cache.com/x/filters:format(jpeg):quality(100):no_upscale():strip_exif()/https%3A%2F%2Fsweet-potato.jpg%3Fis_sweet%3Dyes%20and%20no'
     );
   });
 

--- a/src/admin/aws/utils.ts
+++ b/src/admin/aws/utils.ts
@@ -34,7 +34,7 @@ export function getPocketCacheUrl(url: string) {
     return url;
   }
 
-  return `https://pocket-image-cache.com/x/filters:format(jpeg):quality(100):no_upscale():strip_exif()/${encodeURI(
+  return `https://pocket-image-cache.com/x/filters:format(jpeg):quality(100):no_upscale():strip_exif()/${encodeURIComponent(
     url
   )}`;
 }


### PR DESCRIPTION
## Goal
encode the path and query params in the imageUrl

- some of the images were failing coz the query params were not encoded, adding a fix to this

JIRA ticket:
https://getpocket.atlassian.net/browse/INFRA-339

