### PR TITLE
feat(scheduledItem): sort scheduled items by createdAt asc

### DIFF
--- a/src/admin/resolvers/queries/ScheduledItem.integration.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.integration.ts
@@ -151,6 +151,32 @@ describe('queries: ScheduledCorpusItem', () => {
       expect(resultArray[1].scheduledDate).to.equal('2050-01-01');
     });
 
+    it('should sort items by scheduleDate asc and updatedAt asc', async () => {
+      const result = await server.executeOperation({
+        query: GET_SCHEDULED_ITEMS,
+        variables: {
+          filters: {
+            scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+            startDate: '2050-01-01',
+            endDate: '2050-01-01',
+          },
+        },
+      });
+
+      const resultArray = result.data?.getScheduledCorpusItems;
+
+      // get an array of the createdAt values in the order they were returned
+      const updatedAtDates = resultArray[0].items.map((item) => {
+        return item.updatedAt;
+      });
+
+      // sort those createdAt values
+      const sortedUpdatedAtDates = updatedAtDates.sort();
+
+      // the returned order should match the sorted order
+      expect(updatedAtDates).to.deep.equal(sortedUpdatedAtDates);
+    });
+
     it('should fail on invalid Scheduled Surface GUID', async () => {
       const invalidId = 'not-a-valid-id-by-any-means';
 

--- a/src/database/queries/ScheduledItem.ts
+++ b/src/database/queries/ScheduledItem.ts
@@ -28,7 +28,9 @@ export async function getScheduledItems(
 
   // Get a flat array of scheduled items from Prisma
   const items = await db.scheduledItem.findMany({
-    orderBy: { scheduledDate: 'asc' },
+    // we need to order by scheduleDate first, as we perform a programmatic
+    // groupBy below on that field
+    orderBy: [{ scheduledDate: 'asc' }, { updatedAt: 'asc' }],
     where: {
       scheduledSurfaceGuid: { equals: scheduledSurfaceGuid },
       scheduledDate: {
@@ -86,6 +88,7 @@ export async function getItemsForScheduledSurface(
 ): Promise<ScheduledSurfaceItem[]> {
   // Get a flat array of scheduled items from Prisma
   const items = await db.scheduledItem.findMany({
+    orderBy: { updatedAt: 'asc' },
     where: {
       scheduledSurfaceGuid: { equals: id },
       scheduledDate: date,

--- a/src/public/resolvers/queries/ScheduledSurfaceItem.integration.ts
+++ b/src/public/resolvers/queries/ScheduledSurfaceItem.integration.ts
@@ -94,6 +94,26 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       expect(item.corpusItem.publisher).not.to.be.null;
     });
 
+    it('should sort the items by updatedAt asc', async () => {
+      const result = await server.executeOperation({
+        query: GET_SCHEDULED_SURFACE_WITH_ITEMS,
+        variables: {
+          id: 'NEW_TAB_EN_US',
+          date: '2025-05-05',
+        },
+      });
+
+      const items = result.data?.scheduledSurface.items;
+
+      const updatedAtDates = items.map((item) => {
+        return item.updatedAt;
+      });
+
+      const sortedUpdatedAtDates = updatedAtDates.sort();
+
+      expect(updatedAtDates).to.deep.equal(sortedUpdatedAtDates);
+    });
+
     it('should return an empty result set if nothing is available', async () => {
       const result = await server.executeOperation({
         query: GET_SCHEDULED_SURFACE_WITH_ITEMS,


### PR DESCRIPTION
## Goal

sort scheduled items by `updatedAt 'asc'`.

- sorting for both admin and public queries

## I'd love feedback/perspectives on:
- do we need both public and admin queries sorted?

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1391