### PR TITLE
fix: rename event bus payload property

### DIFF
--- a/src/events/eventBus/EventBusConfig.ts
+++ b/src/events/eventBus/EventBusConfig.ts
@@ -57,8 +57,8 @@ const payloadBuilders = {
   ): ScheduledItemEventBusPayload {
     return {
       eventType: eventType,
-      scheduledItemId: data.scheduledCorpusItem.externalId,
-      approvedItemId: data.scheduledCorpusItem.approvedItem.externalId,
+      scheduledItemExternalId: data.scheduledCorpusItem.externalId,
+      approvedItemExternalId: data.scheduledCorpusItem.approvedItem.externalId,
       url: data.scheduledCorpusItem.approvedItem.url,
       title: data.scheduledCorpusItem.approvedItem.title,
       excerpt: data.scheduledCorpusItem.approvedItem.excerpt,

--- a/src/events/eventBus/EventBusHandler.spec.ts
+++ b/src/events/eventBus/EventBusHandler.spec.ts
@@ -133,8 +133,8 @@ describe('EventBusHandler', () => {
       ScheduledItemEventBusPayload,
       'eventType'
     > = {
-      scheduledItemId: '789-xyz',
-      approvedItemId: '123-abc',
+      scheduledItemExternalId: '789-xyz',
+      approvedItemExternalId: '123-abc',
       url: 'https://test.com/a-story',
       title: 'Everything you need to know about React',
       excerpt: 'Something here',

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -52,8 +52,8 @@ export type ScheduledItemEventBusPayload = BaseEventBusPayload &
     ApprovedItem,
     'topic' | 'isSyndicated' | keyof Omit<CorpusItem, 'id'>
   > & {
-    scheduledItemId: string; // externalId of ScheduledItem
-    approvedItemId: string; // externalId of ApprovedItem
+    scheduledItemExternalId: string; // externalId of ScheduledItem
+    approvedItemExternalId: string; // externalId of ApprovedItem
     scheduledDate: string; // UTC Date string YYYY-MM-DD
     createdAt: string; // UTC timestamp string
     updatedAt: string; // UTC timestamp string


### PR DESCRIPTION
## Goal

Rename event properties to match expectations in data sync service:
`scheduledItemId` => `scheduledItemExternalId`
`approvedItemId` => `approvedItemExternalId`

## References

JIRA ticket: INFRA-393
