### PR TITLE
fix: rename event bus payload property approvedItemId -> approvedItemExternalId

### DIFF
--- a/src/events/eventBus/EventBusConfig.ts
+++ b/src/events/eventBus/EventBusConfig.ts
@@ -83,7 +83,7 @@ const payloadBuilders = {
     const item = data.reviewedCorpusItem;
     return {
       eventType: eventType,
-      approvedItemId: item.externalId,
+      approvedItemExternalId: item.externalId,
       url: item.url,
       title: item.title ?? undefined,
       excerpt: 'excerpt' in item ? item.excerpt : undefined,

--- a/src/events/eventBus/EventBusHandler.spec.ts
+++ b/src/events/eventBus/EventBusHandler.spec.ts
@@ -86,7 +86,7 @@ describe('EventBusHandler', () => {
   describe('approved item events', () => {
     it('update-approved-item should send event with proper data', async () => {
       const expectedEvent: ApprovedItemEventBusPayload = {
-        approvedItemId: '123-abc',
+        approvedItemExternalId: '123-abc',
         url: 'https://test.com/a-story',
         title: 'Everything you need to know about React',
         excerpt: 'Something here',

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -74,7 +74,7 @@ export type ApprovedItemEventBusPayload = BaseEventBusPayload &
       | 'createdBy'
     >
   > & {
-    approvedItemId: string; // externalId of ApprovedItem
+    approvedItemExternalId: string; // externalId of ApprovedItem
     createdAt?: string; // UTC timestamp string
     updatedAt: string; // UTC timestamp string;
   };


### PR DESCRIPTION
## Goal
Rename event property `approvedItem` -> `approvedItemExternalId`

## References

JIRA ticket: INFRA-393