### PR TITLE
chore(errors): use our custom error formatter from apollo-utils

### DIFF
--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -186,11 +186,12 @@ describe('mutations: ApprovedItem', () => {
       // ...without success. There is no data
       expect(result.errors).not.to.be.null;
 
+      expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
+
       // And there is the correct error from the resolvers
       expect(result.errors?.[0].message).to.contain(
         `An approved item with the URL "${input.url}" already exists`
       );
-      expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
 
       // Check that the ADD_ITEM event was not fired
       expect(eventTracker.callCount).to.equal(0);
@@ -343,7 +344,12 @@ describe('mutations: ApprovedItem', () => {
       expect(eventTracker.callCount).to.equal(0);
     });
 
-    it('should fail if language code is outside of allowed values', async () => {
+    // TODO: figure out how to fix these tests
+
+    // the error thrown *is* a UserInputError - BUT it comes from graphql. the
+    // instanceOf check fails. this must be a different UserInputError based on
+    // the source/because it's from graphql directly.
+    it.skip('should fail if language code is outside of allowed values', async () => {
       input.language = 'ZZ';
 
       const result = await server.executeOperation({
@@ -360,7 +366,7 @@ describe('mutations: ApprovedItem', () => {
       );
     });
 
-    it('should fail if language code is correct but not in upper case', async () => {
+    it.skip('should fail if language code is correct but not in upper case', async () => {
       input.language = 'de';
 
       const result = await server.executeOperation({
@@ -547,7 +553,12 @@ describe('mutations: ApprovedItem', () => {
       expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
     });
 
-    it('should fail if language code is outside of allowed values', async () => {
+    // TODO: figure out how to fix these tests
+
+    // the error thrown *is* a UserInputError - BUT it comes from graphql. the
+    // instanceOf check fails. this must be a different UserInputError based on
+    // the source/because it's from graphql directly.
+    it.skip('should fail if language code is outside of allowed values', async () => {
       input.language = 'ZZ';
 
       const result = await server.executeOperation({
@@ -564,7 +575,7 @@ describe('mutations: ApprovedItem', () => {
       );
     });
 
-    it('should fail if language code is correct but not in upper case', async () => {
+    it.skip('should fail if language code is correct but not in upper case', async () => {
       input.language = 'de';
 
       const result = await server.executeOperation({

--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -344,12 +344,7 @@ describe('mutations: ApprovedItem', () => {
       expect(eventTracker.callCount).to.equal(0);
     });
 
-    // TODO: figure out how to fix these tests
-
-    // the error thrown *is* a UserInputError - BUT it comes from graphql. the
-    // instanceOf check fails. this must be a different UserInputError based on
-    // the source/because it's from graphql directly.
-    it.skip('should fail if language code is outside of allowed values', async () => {
+    it('should fail if language code is outside of allowed values', async () => {
       input.language = 'ZZ';
 
       const result = await server.executeOperation({
@@ -366,7 +361,7 @@ describe('mutations: ApprovedItem', () => {
       );
     });
 
-    it.skip('should fail if language code is correct but not in upper case', async () => {
+    it('should fail if language code is correct but not in upper case', async () => {
       input.language = 'de';
 
       const result = await server.executeOperation({
@@ -553,12 +548,7 @@ describe('mutations: ApprovedItem', () => {
       expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
     });
 
-    // TODO: figure out how to fix these tests
-
-    // the error thrown *is* a UserInputError - BUT it comes from graphql. the
-    // instanceOf check fails. this must be a different UserInputError based on
-    // the source/because it's from graphql directly.
-    it.skip('should fail if language code is outside of allowed values', async () => {
+    it('should fail if language code is outside of allowed values', async () => {
       input.language = 'ZZ';
 
       const result = await server.executeOperation({
@@ -575,7 +565,7 @@ describe('mutations: ApprovedItem', () => {
       );
     });
 
-    it.skip('should fail if language code is correct but not in upper case', async () => {
+    it('should fail if language code is correct but not in upper case', async () => {
       input.language = 'de';
 
       const result = await server.executeOperation({

--- a/src/admin/resolvers/mutations/ApprovedItem.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.ts
@@ -1,4 +1,4 @@
-import { UserInputError } from 'apollo-server';
+import { UserInputError } from 'apollo-server-errors';
 import { ApprovedItem } from '@prisma/client';
 import {
   createApprovedItem as dbCreateApprovedItem,

--- a/src/admin/resolvers/mutations/RejectedItem.integration.ts
+++ b/src/admin/resolvers/mutations/RejectedItem.integration.ts
@@ -334,7 +334,12 @@ describe('mutations: RejectedItem', () => {
       );
     });
 
-    it('should fail if language code is outside of allowed values', async () => {
+    // TODO: figure out how to fix these tests
+
+    // the error thrown *is* a UserInputError - BUT it comes from graphql. the
+    // instanceOf check fails. this must be a different UserInputError based on
+    // the source/because it's from graphql directly.
+    it.skip('should fail if language code is outside of allowed values', async () => {
       input.language = 'ZZ';
 
       const result = await server.executeOperation({
@@ -351,7 +356,7 @@ describe('mutations: RejectedItem', () => {
       );
     });
 
-    it('should fail if language code is correct but not in upper case', async () => {
+    it.skip('should fail if language code is correct but not in upper case', async () => {
       input.language = 'de';
 
       const result = await server.executeOperation({
@@ -361,7 +366,6 @@ describe('mutations: RejectedItem', () => {
 
       expect(result.errors).not.to.be.undefined;
       expect(result.data).to.be.oneOf([null, undefined]);
-
       expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
       expect(result.errors?.[0].message).to.contain(
         'does not exist in "CorpusLanguage" enum.'

--- a/src/admin/resolvers/mutations/RejectedItem.integration.ts
+++ b/src/admin/resolvers/mutations/RejectedItem.integration.ts
@@ -334,12 +334,7 @@ describe('mutations: RejectedItem', () => {
       );
     });
 
-    // TODO: figure out how to fix these tests
-
-    // the error thrown *is* a UserInputError - BUT it comes from graphql. the
-    // instanceOf check fails. this must be a different UserInputError based on
-    // the source/because it's from graphql directly.
-    it.skip('should fail if language code is outside of allowed values', async () => {
+    it('should fail if language code is outside of allowed values', async () => {
       input.language = 'ZZ';
 
       const result = await server.executeOperation({
@@ -356,7 +351,7 @@ describe('mutations: RejectedItem', () => {
       );
     });
 
-    it.skip('should fail if language code is correct but not in upper case', async () => {
+    it('should fail if language code is correct but not in upper case', async () => {
       input.language = 'de';
 
       const result = await server.executeOperation({

--- a/src/admin/resolvers/mutations/RejectedItem.ts
+++ b/src/admin/resolvers/mutations/RejectedItem.ts
@@ -1,6 +1,5 @@
-import { UserInputError } from 'apollo-server';
+import { AuthenticationError, UserInputError } from 'apollo-server-errors';
 import { RejectedCuratedCorpusItem } from '@prisma/client';
-import { AuthenticationError } from 'apollo-server-core';
 import { createRejectedItem as dbCreateRejectedItem } from '../../../database/mutations';
 import { ReviewedCorpusItemEventType } from '../../../events/types';
 import { RejectionReason, ACCESS_DENIED_ERROR } from '../../../shared/types';

--- a/src/admin/resolvers/mutations/ScheduledItem.integration.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.integration.ts
@@ -97,9 +97,7 @@ describe('mutations: ScheduledItem', () => {
       expect(result.errors?.[0].message).to.contain(
         `Cannot create a scheduled entry: Approved Item with id "not-a-valid-id-at-all" does not exist.`
       );
-      expect(result.errors?.[0].extensions?.code).to.equal(
-        'INTERNAL_SERVER_ERROR'
-      );
+      expect(result.errors?.[0].extensions?.code).to.equal('NOT_FOUND');
 
       // Check that the ADD_SCHEDULE event was not fired
       expect(eventTracker.callCount).to.equal(0);
@@ -341,9 +339,7 @@ describe('mutations: ScheduledItem', () => {
       expect(result.errors?.[0].message).to.contain(
         `Item with ID of '${input.externalId}' could not be found.`
       );
-      expect(result.errors?.[0].extensions?.code).to.equal(
-        'INTERNAL_SERVER_ERROR'
-      );
+      expect(result.errors?.[0].extensions?.code).to.equal('NOT_FOUND');
 
       // Check that the REMOVE_SCHEDULE event was not fired
       expect(eventTracker.callCount).to.equal(0);
@@ -539,9 +535,7 @@ describe('mutations: ScheduledItem', () => {
         `Item with ID of '${input.externalId}' could not be found.`
       );
 
-      expect(result.errors?.[0].extensions?.code).to.equal(
-        'INTERNAL_SERVER_ERROR'
-      );
+      expect(result.errors?.[0].extensions?.code).to.equal('NOT_FOUND');
 
       // Check that the REMOVE_SCHEDULE event was not fired
       expect(eventTracker.callCount).to.equal(0);

--- a/src/admin/resolvers/mutations/ScheduledItem.ts
+++ b/src/admin/resolvers/mutations/ScheduledItem.ts
@@ -7,7 +7,7 @@ import { ScheduledItem } from '../../../database/types';
 import { ACCESS_DENIED_ERROR } from '../../../shared/types';
 import { scheduledSurfaceAllowedValues } from '../../../shared/utils';
 import { ScheduledCorpusItemEventType } from '../../../events/types';
-import { UserInputError } from 'apollo-server';
+import { UserInputError } from 'apollo-server-errors';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
 import { AuthenticationError } from 'apollo-server-errors';
 import { NotFoundError } from '@pocket-tools/apollo-utils';
@@ -117,7 +117,7 @@ export async function createScheduledItem(
     }
 
     // If it's something else, throw the error unchanged.
-    throw new Error(error);
+    throw error;
   }
 }
 

--- a/src/admin/resolvers/queries/ApprovedItem.auth.integration.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.auth.integration.ts
@@ -60,7 +60,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_APPROVED_ITEMS,
@@ -71,8 +70,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
 
       // should return all 3 items
       expect(result.data?.getApprovedCorpusItems.edges).to.have.length(3);
-
-      await server.stop();
     });
 
     it('should get all items when user has only one scheduled surface access', async () => {
@@ -84,7 +81,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_APPROVED_ITEMS,
@@ -95,8 +91,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
 
       // should return all 3 items
       expect(result.data?.getApprovedCorpusItems.edges).to.have.length(3);
-
-      await server.stop();
     });
 
     it('should throw an error when user does not have the required access', async () => {
@@ -133,7 +127,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_APPROVED_ITEMS,
@@ -145,8 +138,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
       // check if the error we get is access denied error
       expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
       expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
-
-      await server.stop();
     });
   });
 
@@ -160,7 +151,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_APPROVED_ITEM_BY_URL,
@@ -171,8 +161,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
 
       expect(result.data).not.to.be.null;
       expect(result.errors).to.be.undefined;
-
-      await server.stop();
     });
 
     it('should get item when user has only one scheduled surface access', async () => {
@@ -184,7 +172,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_APPROVED_ITEM_BY_URL,
@@ -195,8 +182,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
 
       expect(result.data).not.to.be.null;
       expect(result.errors).to.be.undefined;
-
-      await server.stop();
     });
 
     it('should throw an error when user does not have the required access', async () => {
@@ -208,7 +193,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_APPROVED_ITEM_BY_URL,
@@ -223,8 +207,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
       // check if the error we get is access denied error
       expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
       expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
-
-      await server.stop();
     });
 
     it('should throw an error when request header groups are undefined', async () => {
@@ -236,7 +218,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_APPROVED_ITEM_BY_URL,
@@ -251,8 +232,6 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
       // check if the error we get is access denied error
       expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
       expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
-
-      await server.stop();
     });
   });
 });

--- a/src/admin/resolvers/queries/ApprovedItem.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.ts
@@ -1,6 +1,6 @@
 import { Connection } from '@devoxa/prisma-relay-cursor-connection';
 import { ApprovedItem } from '@prisma/client';
-import { AuthenticationError } from 'apollo-server-core';
+import { AuthenticationError } from 'apollo-server-errors';
 import config from '../../../config';
 import {
   getApprovedItems as dbGetApprovedItems,

--- a/src/admin/resolvers/queries/RejectedItem.auth.integration.ts
+++ b/src/admin/resolvers/queries/RejectedItem.auth.integration.ts
@@ -57,7 +57,6 @@ describe('queries: RejectedCorpusItem (authentication)', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_REJECTED_ITEMS,
@@ -68,8 +67,6 @@ describe('queries: RejectedCorpusItem (authentication)', () => {
 
       // should return all four items - the entire corpus should be accessible
       expect(result.data?.getRejectedCorpusItems.edges).to.have.length(4);
-
-      await server.stop();
     });
 
     it('should get all items when user has only one scheduled surface access', async () => {
@@ -80,7 +77,6 @@ describe('queries: RejectedCorpusItem (authentication)', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_REJECTED_ITEMS,
@@ -91,8 +87,6 @@ describe('queries: RejectedCorpusItem (authentication)', () => {
 
       // should return all four items - the entire corpus should be accessible
       expect(result.data?.getRejectedCorpusItems.edges).to.have.length(4);
-
-      await server.stop();
     });
 
     it('should throw an error when user does not have the required access', async () => {
@@ -102,7 +96,6 @@ describe('queries: RejectedCorpusItem (authentication)', () => {
         groups: `this,that`,
       };
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_REJECTED_ITEMS,
@@ -114,15 +107,12 @@ describe('queries: RejectedCorpusItem (authentication)', () => {
       // check if the error we get is the access denied error
       expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
       expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
-
-      await server.stop();
     });
 
     it('should throw an error when request access groups are undefined', async () => {
       // Set up auth headers with no access groups whatsoever (the default
       // on top of the `describe()` block for Rejected Item queries).
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const result = await server.executeOperation({
         query: GET_REJECTED_ITEMS,
@@ -134,8 +124,6 @@ describe('queries: RejectedCorpusItem (authentication)', () => {
       // check if the error we get is the access denied error
       expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
       expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
-
-      await server.stop();
     });
   });
 });

--- a/src/admin/resolvers/queries/ScheduledItem.ts
+++ b/src/admin/resolvers/queries/ScheduledItem.ts
@@ -1,4 +1,4 @@
-import { AuthenticationError } from 'apollo-server-core';
+import { AuthenticationError } from 'apollo-server-errors';
 import { getScheduledItems as dbGetScheduledItems } from '../../../database/queries';
 import { ScheduledItemsResult } from '../../../database/types';
 import { ACCESS_DENIED_ERROR } from '../../../shared/types';

--- a/src/admin/resolvers/queries/ScheduledSurface.auth.integration.ts
+++ b/src/admin/resolvers/queries/ScheduledSurface.auth.integration.ts
@@ -38,7 +38,6 @@ describe('auth: ScheduledSurface', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const { data } = await server.executeOperation({
         query: GET_SCHEDULED_SURFACES_FOR_USER,
@@ -54,8 +53,6 @@ describe('auth: ScheduledSurface', () => {
         expect(scheduledSurface.ianaTimezone).not.to.be.undefined;
         expect(scheduledSurface.prospectTypes).not.to.be.undefined;
       });
-
-      await server.stop();
     });
 
     it('should return a single surface for users with access to one scheduled surface', async () => {

--- a/src/admin/server.ts
+++ b/src/admin/server.ts
@@ -5,7 +5,7 @@ import { typeDefsAdmin } from '../typeDefs';
 import { resolvers as resolversAdmin } from './resolvers';
 import responseCachePlugin from 'apollo-server-plugin-response-cache';
 import { GraphQLRequestContext } from 'apollo-server-types';
-import { sentryPlugin } from '@pocket-tools/apollo-utils';
+import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
 import { ContextManager } from './context';
 import {
   ApolloServerPluginLandingPageDisabled,
@@ -46,6 +46,7 @@ export function getServer(contextFactory: ContextFactory): ApolloServer {
         : ApolloServerPluginLandingPageGraphQLPlayground(),
     ],
     context: ({ req }) => contextFactory(req),
+    formatError: errorHandler,
   });
 }
 

--- a/src/admin/server.ts
+++ b/src/admin/server.ts
@@ -1,3 +1,4 @@
+import { UserInputError } from 'apollo-server';
 import { ApolloServer } from 'apollo-server-express';
 import { Request } from 'express';
 import { buildSubgraphSchema } from '@apollo/federation';
@@ -46,7 +47,83 @@ export function getServer(contextFactory: ContextFactory): ApolloServer {
         : ApolloServerPluginLandingPageGraphQLPlayground(),
     ],
     context: ({ req }) => contextFactory(req),
-    formatError: errorHandler,
+    formatError: (error) => {
+      // what in the heckaroonie is this? why can't we just do:
+      //
+      // formatError: errorHandler
+      //
+      // sit down by the fire weary traveler, and let me tell you a tale...
+      //
+      // once upon a time there was a devious and tricky beast. where this beast came
+      // from was never fully known, but rumors spread it had arisen from the
+      // dark land of Legacy Support. the true name of this fiend cannot be spoken
+      // by the human tongue, but in common it is simply referred to as the Import
+      // Triad of Doom. steel yourself dear traveler, and gaze thine eyes upon an
+      // image of this fiend:
+      //
+      // import { UserInputError } from 'apollo-server';
+      // import { UserInputError } from 'apollo-server-core';
+      // import { UserInputError } from 'apollo-server-errors';
+      //
+      // three bodies, all *functionally* the same. gasp!
+      //
+      // with pure and perhaps foolish intent, in order to better understand the
+      // beast, i snuck upon it as it slept and with the utmost quiet cast `instanceOf`.
+      // dear traveler, it pains me to tell you that while the spell worked, my
+      // stealth check failed! the incantation revealed the beast to be different
+      // demons from parallel planes, somehow conjoined into a single monstrosity!
+      //
+      // the creature then awoke, and with a single wave of a hand, cast me into the
+      // hidden dungeon that is errors thrown directly from a graphql schema
+      // violation. battered and low on HP from a three day journey to track the
+      // fiend, there i lay, too weary to move.
+      //
+      // as the light faded and my eyes grew heavy, a silhouette emerged at the
+      // mouth of the dungeon. could it be? is it...? yes? YES! my long-time
+      // comrade, slayer of many a foe, the great kelvin!
+      //
+      // half conscious, kelvin sat me up and offered waterskin and lambas bread.
+      // "stay here, i will go on to discover the secret of this dungeon and return
+      // for you."
+      //
+      // time held no meaning for me then. my only energy spent carefully chewing
+      // and drinking, fading in and out between nourishments. darkness washed over
+      // me.
+      //
+      // as promised, kelvin returned.
+      //
+      // "the riddle has been solved. when a graphql schema violation occurs, the great
+      // apollo itself is cruelly conjuring `UserInputError` from `apollo-server`
+      // of the forsaken land of Legacy Support. yes, the same origin of the hideous
+      // Import Triad of Doom. sometimes, even the gods make mistakes."
+      //
+      // kelvin then showed me the below wrapper spell, which accounts for the mistakes
+      // of the gods, until they should find time to fix them.
+      //
+      // the best lives on to this day, contained, yet still dangerous to those
+      // unfortunate enough to cross its path.
+      //
+      // be wary, traveler, and double-check your imports.
+      //
+      // ~ fin
+      //
+      // the moral of the story:
+      //
+      // in our `apollo-utils` `errorHandler`, we are checking `instanceOf ApolloError`,
+      // with `ApolloError` imported from the recommended `apollo-server-errors`
+      // package. (see the source:
+      // https://github.com/Pocket/apollo-utils/blob/main/src/errorHandler/errorHandler.ts#L10-L24))
+      //
+      // however, when a graphql schema violation occurs, apollo is throwing a
+      // `UserInputError`, which is what we expect, but they are importing this error
+      // from `apollo-server`, which causes our `instanceOf` check to fail.
+      //
+      if (error instanceof UserInputError) {
+        return error;
+      } else {
+        return errorHandler(error);
+      }
+    },
   });
 }
 

--- a/src/database/helpers/checkCorpusUrl.ts
+++ b/src/database/helpers/checkCorpusUrl.ts
@@ -1,4 +1,4 @@
-import { UserInputError } from 'apollo-server';
+import { UserInputError } from 'apollo-server-errors';
 import { PrismaClient } from '@prisma/client';
 
 /**

--- a/src/database/mutations/ApprovedItem.ts
+++ b/src/database/mutations/ApprovedItem.ts
@@ -4,7 +4,7 @@ import {
   ImportApprovedItemInput,
   UpdateApprovedItemInput,
 } from '../types';
-import { ApolloError, UserInputError } from 'apollo-server';
+import { ApolloError, UserInputError } from 'apollo-server-errors';
 import { checkCorpusUrl } from '../helpers/checkCorpusUrl';
 
 /**

--- a/src/database/queries/ScheduledItem.ts
+++ b/src/database/queries/ScheduledItem.ts
@@ -8,6 +8,7 @@ import {
 } from '../types';
 import { scheduledSurfaceAllowedValues } from '../../shared/utils';
 import { groupBy } from '../../shared/utils';
+import { UserInputError } from 'apollo-server-errors';
 
 /**
  * @param db
@@ -21,7 +22,7 @@ export async function getScheduledItems(
 
   // validate scheduledSurfaceGuid
   if (!scheduledSurfaceAllowedValues.includes(scheduledSurfaceGuid)) {
-    throw new Error(
+    throw new UserInputError(
       `${scheduledSurfaceGuid} is not a valid Scheduled Surface GUID`
     );
   }

--- a/src/public/resolvers/queries/ScheduledSurface.ts
+++ b/src/public/resolvers/queries/ScheduledSurface.ts
@@ -1,6 +1,6 @@
 import { ScheduledSurface } from '../../../database/types';
 import { ScheduledSurfaces } from '../../../shared/types';
-import { UserInputError } from 'apollo-server';
+import { UserInputError } from 'apollo-server-errors';
 
 /**
  * Retrieves a Scheduled Surface (for example, New Tab) for a given GUID.

--- a/src/public/server.ts
+++ b/src/public/server.ts
@@ -4,7 +4,7 @@ import { typeDefsPublic } from '../typeDefs';
 import { resolvers } from './resolvers';
 import responseCachePlugin from 'apollo-server-plugin-response-cache';
 import { GraphQLRequestContext } from 'apollo-server-types';
-import { sentryPlugin } from '@pocket-tools/apollo-utils';
+import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
 import {
   ApolloServerPluginLandingPageDisabled,
   ApolloServerPluginLandingPageGraphQLPlayground,
@@ -33,4 +33,5 @@ export const server = new ApolloServer({
   context: {
     db: client(),
   },
+  formatError: errorHandler,
 });

--- a/src/test/admin-server.ts
+++ b/src/test/admin-server.ts
@@ -1,3 +1,4 @@
+import { UserInputError } from 'apollo-server';
 import { ApolloServer } from 'apollo-server-express';
 import { buildSubgraphSchema } from '@apollo/federation';
 import {
@@ -47,6 +48,14 @@ export const getServer = (
       ApolloServerPluginInlineTraceDisabled(),
       ApolloServerPluginUsageReportingDisabled(),
     ],
-    formatError: errorHandler,
+    formatError: (error) => {
+      // for an explanation of the below, see the comment in
+      // src/admin/server.ts
+      if (error instanceof UserInputError) {
+        return error;
+      } else {
+        return errorHandler(error);
+      }
+    },
   });
 };

--- a/src/test/admin-server.ts
+++ b/src/test/admin-server.ts
@@ -11,6 +11,7 @@ import { client } from '../database/client';
 import { CuratedCorpusEventEmitter } from '../events/curatedCorpusEventEmitter';
 import { ContextManager } from '../admin/context';
 import s3 from '../admin/aws/s3';
+import { errorHandler } from '@pocket-tools/apollo-utils';
 
 // Export this separately so that it can be used in Apollo integration tests
 export const db = client();
@@ -46,5 +47,6 @@ export const getServer = (
       ApolloServerPluginInlineTraceDisabled(),
       ApolloServerPluginUsageReportingDisabled(),
     ],
+    formatError: errorHandler,
   });
 };


### PR DESCRIPTION
## Goal

implement our custom error formatter.

- clean up a few other things
- some tests skipped as they do not yet work with our custom formatter

## I'd love feedback/perspectives on:
- shipping this - are any clients (curation admin tools, the backfill perhaps) relying on the existing error codes?

## Implementation Decisions
- ~skipping tests that deliberately trigger graph-level errors. our custom formatter cannot currently capture/identify these. is it okay to ship skipping these tests? would it be better to test for the existing (but incorrect) result of getting an `INTERNAL_SERVER_ERROR`?~ with kelvin's help, i worked around this issue and there are no longer any tests skipped.