### PR TITLE
fix(query): [BACK-1433] Public query returns too many results

### DIFF
--- a/src/public/resolvers/queries/ScheduledSurfaceItem.integration.ts
+++ b/src/public/resolvers/queries/ScheduledSurfaceItem.integration.ts
@@ -46,6 +46,19 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
           scheduledDate: new Date('2025-05-05').toISOString(),
         });
       }
+
+      // Create another batch of approved items for a different scheduled surface GUID
+      // but the same date as the first batch
+      for (let i = 0; i < 7; i++) {
+        const approvedItem = await createApprovedItemHelper(db, {
+          title: `Batch 3, Story #${i + 1}`,
+        });
+        await createScheduledItemHelper(db, {
+          scheduledSurfaceGuid: 'POCKET_HITS_EN_US',
+          approvedItem,
+          scheduledDate: new Date('2050-01-01').toISOString(),
+        });
+      }
     });
 
     it('should return all requested items', async () => {
@@ -62,6 +75,22 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       expect(result.data).not.to.be.null;
 
       expect(result.data?.scheduledSurface.items).to.have.lengthOf(5);
+    });
+
+    it('should return items for requested scheduled surface only', async () => {
+      const result = await server.executeOperation({
+        query: GET_SCHEDULED_SURFACE_WITH_ITEMS,
+        variables: {
+          id: 'POCKET_HITS_EN_US',
+          date: '2050-01-01',
+        },
+      });
+
+      // Good to check this here before we get into actual return values
+      expect(result.errors).to.be.undefined;
+      expect(result.data).not.to.be.null;
+
+      expect(result.data?.scheduledSurface.items).to.have.lengthOf(7);
     });
 
     it('should return all expected properties', async () => {

--- a/src/public/resolvers/queries/ScheduledSurfaceItem.ts
+++ b/src/public/resolvers/queries/ScheduledSurfaceItem.ts
@@ -13,6 +13,10 @@ export async function getItemsForScheduledSurface(
   args,
   { db }
 ): Promise<ScheduledSurfaceItem[]> {
-  const { id, date } = args;
+  const { date } = args;
+
+  // The value of scheduled surface ID comes from the parent query
+  const { id } = parent;
+
   return await dbGetItemsForScheduledSurface(db, id, date);
 }


### PR DESCRIPTION
## Goal

Investigate the public query that returned too many results (or, for Pocket Hits, results _at all_). 

- It turns out the `items` subquery within the `scheduledSurface` query never got the correct value for scheduled surface GUID. Now fixed.

- Added an integration tests that checks that the code is really fixed.


## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1433