### PR TITLE
feat(history): [BACK-1439] Add `scheduledSurfaceHistory` subquery to ApprovedItem

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -201,7 +201,10 @@ type ApprovedCorpusItem @key(fields: "url") {
     """
     Subquery to get the ScheduledCorpusItems to display to a user for a given date
     """
-    scheduledSurfaceHistory(scheduledSurfaceGuid: ID, limit: Int): [ScheduledCorpusItem!]!
+    scheduledSurfaceHistory(
+        scheduledSurfaceGuid: ID
+        limit: Int
+    ): [ScheduledCorpusItem!]!
 }
 
 """
@@ -355,7 +358,7 @@ type ScheduledCorpusItem {
     """
     The associated Approved Item.
     """
-    approvedItem: ApprovedCorpusItem
+    approvedItem: ApprovedCorpusItem!
     """
     The GUID of this scheduledSurface to which this item is scheduled. Example: 'NEW_TAB_EN_US'.
     """

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -199,12 +199,10 @@ type ApprovedCorpusItem @key(fields: "url") {
     """
     updatedBy: String
     """
-    Subquery to get the ScheduledCorpusItems to display to a user for a given date
+    Subquery to get the log of scheduled entries to display for a given Approved Item, most recent first.
     """
-    scheduledSurfaceHistory(
-        scheduledSurfaceGuid: ID
-        limit: Int
-    ): [ScheduledCorpusItem!]!
+    scheduledSurfaceHistory(filters: ApprovedCorpusItemScheduledSurfaceHistoryFilters):
+        [ApprovedCorpusItemScheduledSurfaceHistory!]!
 }
 
 """
@@ -417,6 +415,45 @@ input ApprovedCorpusItemFilter {
     """
     language: CorpusLanguage
 }
+
+type ApprovedCorpusItemScheduledSurfaceHistory {
+    """
+    An alternative primary key in UUID format that is generated on creation.
+    Note: this is the external ID of the scheduled entry, not the approved item.
+    """
+    externalId: ID!
+    """
+    A single sign-on user identifier of the user who created this entry.
+    """
+    createdBy: String!
+    """
+    The date the associated Approved Item is scheduled to appear on a Scheduled Surface.
+    This date is relative to the time zone of the Scheduled Surface. Format: YYYY-MM-DD.
+    """
+    scheduledDate: Date!
+    """
+    The GUID of the scheduledSurface to which the associated Approved Item is scheduled.
+    Example: 'NEW_TAB_EN_US'.
+    """
+    scheduledSurfaceGuid: ID!
+}
+
+"""
+Available fields for filtering an Approved Item's history of being scheduled onto one or more
+scheduled surfaces.
+"""
+input ApprovedCorpusItemScheduledSurfaceHistoryFilters {
+    """
+    The maximum number of results to be returned. Default: 10.
+    """
+    limit: NonNegativeInt
+    """
+    The scheduled surface the results should be filtered to. Omitting this filter will
+    fetch results from all scheduled surfaces.
+    """
+    scheduledSurfaceGuid: ID
+}
+
 
 """
 Available fields for filtering Rejected Items.

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -120,13 +120,6 @@ type ScheduledSurface {
 }
 
 """
-Temp type to pacify federation checks
-"""
-type ApprovedCuratedCorpusItem @key(fields: "url") {
-    url: Url!
-}
-
-"""
 A prospective story that has been reviewed by the curators and saved to the corpus.
 """
 type ApprovedCorpusItem @key(fields: "url") {
@@ -205,6 +198,10 @@ type ApprovedCorpusItem @key(fields: "url") {
     A single sign-on user identifier of the user who last updated this entity. Null on creation.
     """
     updatedBy: String
+    """
+    Subquery to get the ScheduledCorpusItems to display to a user for a given date
+    """
+    scheduledSurfaceHistory(scheduledSurfaceGuid: ID, limit: Int): [ScheduledCorpusItem!]!
 }
 
 """
@@ -358,7 +355,7 @@ type ScheduledCorpusItem {
     """
     The associated Approved Item.
     """
-    approvedItem: ApprovedCorpusItem!
+    approvedItem: ApprovedCorpusItem
     """
     The GUID of this scheduledSurface to which this item is scheduled. Example: 'NEW_TAB_EN_US'.
     """

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -7,6 +7,10 @@ scalar Url
 A date in the YYYY-MM-DD format.
 """
 scalar Date
+"""
+A positive integer number.
+"""
+scalar NonNegativeInt
 
 """
 Valid language codes for curated corpus items.

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -1,4 +1,4 @@
-import { DateResolver } from 'graphql-scalars';
+import { DateResolver, NonNegativeIntResolver } from 'graphql-scalars';
 import { UnixTimestampResolver } from './fields/UnixTimestamp';
 import {
   getApprovedItems,
@@ -32,6 +32,7 @@ export const resolvers = {
   Upload: GraphQLUpload,
   // The custom scalars from GraphQL-Scalars that we find useful.
   Date: DateResolver,
+  NonNegativeInt: NonNegativeIntResolver,
 
   ApprovedCorpusItem: {
     // Our own entities that need timestamp conversion, hence field resolvers

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -1,6 +1,10 @@
 import { DateResolver } from 'graphql-scalars';
 import { UnixTimestampResolver } from './fields/UnixTimestamp';
-import { getApprovedItems, getApprovedItemByUrl } from './queries/ApprovedItem';
+import {
+  getApprovedItems,
+  getApprovedItemByUrl,
+  getScheduledSurfaceHistory,
+} from './queries/ApprovedItem';
 import { getScheduledSurfacesForUser } from './queries/ScheduledSurface';
 import { getRejectedItems } from './queries/RejectedItem';
 import { getScheduledItems } from './queries/ScheduledItem';
@@ -49,6 +53,10 @@ export const resolvers = {
        */
       return dbGetApprovedItemByUrl(db, url);
     },
+
+    // The `scheduledSurfaceHistory` subquery pulls in data on most recent
+    // scheduling of a curated item onto a surface.
+    scheduledSurfaceHistory: getScheduledSurfaceHistory,
   },
   RejectedCorpusItem: {
     createdAt: UnixTimestampResolver,

--- a/src/admin/resolvers/queries/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.integration.ts
@@ -1,14 +1,16 @@
 import { expect } from 'chai';
-import { CuratedStatus } from '@prisma/client';
+import { ApprovedItem, CuratedStatus } from '@prisma/client';
 import { db } from '../../../test/admin-server';
 import {
   clearDb,
   createApprovedItemHelper,
+  createScheduledItemHelper,
   getServerWithMockedHeaders,
 } from '../../../test/helpers';
 import {
   APPROVED_ITEM_REFERENCE_RESOLVER,
   GET_APPROVED_ITEM_BY_URL,
+  GET_APPROVED_ITEM_WITH_SCHEDULING_HISTORY,
   GET_APPROVED_ITEMS,
 } from './sample-queries.gql';
 import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
@@ -389,6 +391,182 @@ describe('queries: ApprovedCorpusItem', () => {
 
       // There should be no errors
       expect(result.errors).to.be.undefined;
+    });
+  });
+
+  describe('getScheduledSurfaceHistory subquery', () => {
+    beforeAll(async () => {
+      // Create a few items with known URLs.
+      const storyInput = [
+        {
+          title: 'Story one',
+          url: 'https://www.test-domain.com/story-one',
+        },
+        {
+          title: 'Story two',
+          url: 'https://www.test-domain.com/story-two',
+        },
+        {
+          title: 'Story three',
+          url: 'https://www.test-domain.com/story-three',
+        },
+      ];
+
+      const stories: ApprovedItem[] = [];
+
+      for (const input of storyInput) {
+        const story = await createApprovedItemHelper(db, input);
+        stories.push(story);
+      }
+
+      // Destructure the first two stories to be able to create scheduled
+      // entries for them
+      const [storyOne, storyTwo] = stories;
+
+      // Set up some scheduled entries for story #1
+      // US New Tab, date in 2050
+      for (let i = 21; i <= 30; i++) {
+        await createScheduledItemHelper(db, {
+          scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+          approvedItem: storyOne,
+          scheduledDate: new Date(`2050-01-${i}`).toISOString(),
+        });
+      }
+      // DE New Tab, same dates
+      for (let i = 11; i <= 20; i++) {
+        await createScheduledItemHelper(db, {
+          scheduledSurfaceGuid: 'NEW_TAB_DE_DE',
+          approvedItem: storyOne,
+          scheduledDate: new Date(`2050-01-${i}`).toISOString(),
+        });
+      }
+      // Set up more scheduled entries for story #2
+      for (let i = 1; i <= 10; i++) {
+        await createScheduledItemHelper(db, {
+          scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+          approvedItem: storyTwo,
+          scheduledDate: new Date(`2050-01-${i}`).toISOString(),
+        });
+      }
+    });
+
+    it('returns an empty array if an Approved Item has not been scheduled onto any surface', async () => {
+      const result = await server.executeOperation({
+        query: GET_APPROVED_ITEM_WITH_SCHEDULING_HISTORY,
+        variables: {
+          url: 'https://www.test-domain.com/story-three',
+        },
+      });
+
+      // There should be no errors
+      expect(result.errors).to.be.undefined;
+
+      // There should be no data returned for the subquery (an empty array),
+      // since the third story doesn't have any scheduled entries in this test suite.
+      expect(
+        result.data?.getApprovedCorpusItemByUrl.scheduledSurfaceHistory
+      ).to.have.lengthOf(0);
+    });
+
+    it('returns an empty array if an Approved item has not been scheduled onto a particular surface', async () => {
+      const result = await server.executeOperation({
+        query: GET_APPROVED_ITEM_WITH_SCHEDULING_HISTORY,
+        variables: {
+          url: 'https://www.test-domain.com/story-two',
+          scheduledSurfaceGuid: 'NEW_TAB_EN_GB',
+        },
+      });
+
+      // There should be no errors
+      expect(result.errors).to.be.undefined;
+
+      // There should be no data returned for the subquery (an empty array),
+      // since the this story doesn't have any entries on the UK New Tab
+      expect(
+        result.data?.getApprovedCorpusItemByUrl.scheduledSurfaceHistory
+      ).to.have.lengthOf(0);
+    });
+
+    it('respects the limit on results', async () => {
+      const result = await server.executeOperation({
+        query: GET_APPROVED_ITEM_WITH_SCHEDULING_HISTORY,
+        variables: {
+          url: 'https://www.test-domain.com/story-two',
+          scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+          limit: 3,
+        },
+      });
+
+      // There should be no errors
+      expect(result.errors).to.be.undefined;
+
+      expect(
+        result.data?.getApprovedCorpusItemByUrl.scheduledSurfaceHistory
+      ).to.have.lengthOf(3);
+    });
+
+    it('returns results for a specified scheduled surface only', async () => {
+      const result = await server.executeOperation({
+        query: GET_APPROVED_ITEM_WITH_SCHEDULING_HISTORY,
+        variables: {
+          url: 'https://www.test-domain.com/story-one',
+          scheduledSurfaceGuid: 'NEW_TAB_DE_DE',
+        },
+      });
+
+      // There should be no errors.
+      expect(result.errors).to.be.undefined;
+
+      // We've got ten of these seeded for this test suite.
+      const history =
+        result.data?.getApprovedCorpusItemByUrl.scheduledSurfaceHistory;
+      expect(history).to.have.lengthOf(10);
+
+      // Let's verify they're all scheduled for DE_DE
+      history.forEach((entry) => {
+        expect(entry.scheduledSurfaceGuid).to.equal('NEW_TAB_DE_DE');
+      });
+    });
+
+    it('returns all entries for a given approved item', async () => {
+      const result = await server.executeOperation({
+        query: GET_APPROVED_ITEM_WITH_SCHEDULING_HISTORY,
+        variables: {
+          url: 'https://www.test-domain.com/story-one',
+          limit: 100,
+        },
+      });
+
+      // There should be no errors.
+      expect(result.errors).to.be.undefined;
+
+      // There's a total of 20 entries for the first story
+      expect(
+        result.data?.getApprovedCorpusItemByUrl.scheduledSurfaceHistory
+      ).to.have.lengthOf(20);
+    });
+
+    it('returns the scheduled entries in descending order', async () => {
+      const result = await server.executeOperation({
+        query: GET_APPROVED_ITEM_WITH_SCHEDULING_HISTORY,
+        variables: {
+          url: 'https://www.test-domain.com/story-one',
+          scheduledSurfaceGuid: 'NEW_TAB_DE_DE',
+        },
+      });
+
+      // There should be no errors.
+      expect(result.errors).to.be.undefined;
+
+      // We've got ten of these seeded for this test suite.
+      const history =
+        result.data?.getApprovedCorpusItemByUrl.scheduledSurfaceHistory;
+      expect(history).to.have.lengthOf(10);
+
+      // Let's verify that the results are being returned in descending order
+      expect(history[0].scheduledDate).to.equal('2050-01-20');
+      expect(history[1].scheduledDate).to.equal('2050-01-19');
+      expect(history[2].scheduledDate).to.equal('2050-01-18');
     });
   });
 

--- a/src/admin/resolvers/queries/ApprovedItem.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../database/queries';
 import { ACCESS_DENIED_ERROR, ScheduledSurfaces } from '../../../shared/types';
 import { IContext } from '../../context';
+import { ApprovedItemScheduledSurfaceHistory } from '../../../database/types';
 
 /**
  * This query retrieves approved items from the database.
@@ -86,7 +87,7 @@ export async function getScheduledSurfaceHistory(
   parent,
   args,
   { db }
-): Promise<ScheduledItem[]> {
+): Promise<ApprovedItemScheduledSurfaceHistory[]> {
   // Get the external ID of the Approved Item itself
   const { externalId } = parent;
 
@@ -100,9 +101,12 @@ export async function getScheduledSurfaceHistory(
   //
   // Limiting the number of results to one means only the most recent result
   // will be returned.
-
-  //TODO: maybe add a config variable for the default limit?
-  const { scheduledSurfaceGuid, limit = 10 } = args;
+  const {
+    filters: {
+      limit = config.app.pagination.scheduledSurfaceHistory,
+      scheduledSurfaceGuid,
+    },
+  } = args;
 
   // Check if the scheduled surface supplied is valid
   const surface = ScheduledSurfaces.find((surface) => {
@@ -112,13 +116,6 @@ export async function getScheduledSurfaceHistory(
   if (!surface) {
     throw new UserInputError(
       `Could not find Scheduled Surface with id of "${scheduledSurfaceGuid}".`
-    );
-  }
-
-  // Check if the limit specified passes basic sanity checks
-  if (limit.isNaN() || limit < 1) {
-    throw new UserInputError(
-      `Please specify the number of results to be returned (one or more).`
     );
   }
 

--- a/src/admin/resolvers/queries/ApprovedItem.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.ts
@@ -100,12 +100,15 @@ export async function getScheduledSurfaceHistory(
   //
   // Limiting the number of results to one means only the most recent result
   // will be returned.
-  const { scheduledSurfaceGuid, limit } = args;
+
+  //TODO: maybe add a config variable for the default limit?
+  const { scheduledSurfaceGuid, limit = 10 } = args;
 
   // Check if the scheduled surface supplied is valid
   const surface = ScheduledSurfaces.find((surface) => {
     return surface.guid === scheduledSurfaceGuid;
   });
+
   if (!surface) {
     throw new UserInputError(
       `Could not find Scheduled Surface with id of "${scheduledSurfaceGuid}".`

--- a/src/admin/resolvers/queries/sample-queries.gql.ts
+++ b/src/admin/resolvers/queries/sample-queries.gql.ts
@@ -81,6 +81,27 @@ export const GET_APPROVED_ITEM_BY_URL = gql`
   ${CuratedItemData}
 `;
 
+export const GET_APPROVED_ITEM_WITH_SCHEDULING_HISTORY = gql`
+  query getApprovedCorpusItemByUrl(
+    $url: String!
+    $scheduledSurfaceGuid: ID
+    $limit: NonNegativeInt
+  ) {
+    getApprovedCorpusItemByUrl(url: $url) {
+      ...CuratedItemData
+      scheduledSurfaceHistory(
+        filters: { scheduledSurfaceGuid: $scheduledSurfaceGuid, limit: $limit }
+      ) {
+        externalId
+        createdBy
+        scheduledDate
+        scheduledSurfaceGuid
+      }
+    }
+  }
+  ${CuratedItemData}
+`;
+
 export const GET_SCHEDULED_SURFACES_FOR_USER = gql`
   query getScheduledSurfacesForUser {
     getScheduledSurfacesForUser {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,6 +23,7 @@ export default {
       approvedItemsPerPage: 30,
       rejectedItemsPerPage: 30,
       maxAllowedResults: 100,
+      scheduledSurfaceHistory: 10,
     },
     upload: {
       maxSize: 10000000, // in bytes => 10MB

--- a/src/database/queries/ApprovedItem.ts
+++ b/src/database/queries/ApprovedItem.ts
@@ -99,9 +99,14 @@ export async function getScheduledSurfaceHistory(
   scheduledSurfaceGuid?: string,
   limit?: number
 ): Promise<ScheduledItem[]> {
-  const approvedItem = db.approvedItem.findUnique({
+  const approvedItem = await db.approvedItem.findUnique({
     where: { externalId },
   });
+
+  // early exit if no approved item is found
+  if (!approvedItem) {
+    return [];
+  }
 
   return await db.scheduledItem.findMany({
     take: limit,

--- a/src/database/queries/ApprovedItem.ts
+++ b/src/database/queries/ApprovedItem.ts
@@ -1,9 +1,9 @@
-import { ApprovedItem, PrismaClient } from '@prisma/client';
 // need this to be able to use Prisma-native types for orderBy and filter clauses
 import * as prisma from '@prisma/client';
+import { ApprovedItem, PrismaClient, ScheduledItem } from '@prisma/client';
 import {
-  findManyCursorConnection,
   Connection,
+  findManyCursorConnection,
 } from '@devoxa/prisma-relay-cursor-connection';
 import { ApprovedItemFilter, PaginationInput } from '../types';
 
@@ -83,6 +83,36 @@ export async function getApprovedItemByUrl(
   url: string
 ): Promise<ApprovedItem | null> {
   return db.approvedItem.findUnique({ where: { url } });
+}
+
+/**
+ *
+ *
+ * @param db
+ * @param externalId
+ * @param scheduledSurfaceGuid
+ * @param limit
+ */
+export async function getScheduledSurfaceHistory(
+  db: PrismaClient,
+  externalId: string,
+  scheduledSurfaceGuid?: string,
+  limit?: number
+): Promise<ScheduledItem[]> {
+  const approvedItem = db.approvedItem.findUnique({
+    where: { externalId },
+  });
+
+  return await db.scheduledItem.findMany({
+    take: limit,
+    orderBy: { scheduledDate: 'desc' },
+    where: {
+      approvedItemId: approvedItem.id,
+      scheduledSurfaceGuid: scheduledSurfaceGuid
+        ? { equals: scheduledSurfaceGuid }
+        : undefined,
+    },
+  });
 }
 
 /**

--- a/src/database/queries/ApprovedItem.ts
+++ b/src/database/queries/ApprovedItem.ts
@@ -11,7 +11,6 @@ import {
   PaginationInput,
 } from '../types';
 import { DateTime } from 'luxon';
-import { UserInputError } from 'apollo-server-errors';
 
 /**
  * A dedicated type for the unique cursor value used in the getCuratedItems query.

--- a/src/database/queries/index.ts
+++ b/src/database/queries/index.ts
@@ -1,4 +1,8 @@
-export { getApprovedItems, getApprovedItemByUrl } from './ApprovedItem';
+export {
+  getApprovedItems,
+  getApprovedItemByUrl,
+  getScheduledSurfaceHistory,
+} from './ApprovedItem';
 export {
   getRejectedCuratedCorpusItems,
   getRejectedItemByUrl,

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -165,3 +165,10 @@ export type ScheduledSurface = {
   name: string;
   items?: ScheduledSurfaceItem[];
 };
+
+export type ApprovedItemScheduledSurfaceHistory = {
+  externalId: string;
+  createdBy: string;
+  scheduledDate: string;
+  scheduledSurfaceGuid: string;
+};


### PR DESCRIPTION
## Goal

We need to add a query that retrieves scheduled entries for a corpus item. 

- Added a subquery to the admin schema.

- Added a resolver that takes in result limit + scheduled surface guid, both optional, and retrieves an array of scheduled items in return.

- [x] Tests ~outstanding~ done
- [x] Review feedback implemented

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1439