### PR TITLE
fix(authors): [BACK-1442] Add authors to Snowplow output

### DIFF
--- a/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
+++ b/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
@@ -9,7 +9,6 @@ import {
 } from '../../test/helpers/snowplow';
 import config from '../../config';
 import {
-  ApprovedItem,
   ReviewedCorpusItemEventType,
   ReviewedCorpusItemPayload,
 } from '../types';
@@ -19,7 +18,7 @@ import { tracker } from './tracker';
 import { CuratedCorpusEventEmitter } from '../curatedCorpusEventEmitter';
 import { getUnixTimestamp } from '../../shared/utils';
 import { CorpusItemSource, Topics } from '../../shared/types';
-import { ApprovedItemAuthor } from '../../database/types';
+import { ApprovedItem, ApprovedItemAuthor } from '../../database/types';
 
 /**
  * Use a simple mock item instead of using DB helpers

--- a/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
+++ b/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
@@ -1,9 +1,5 @@
 import { expect } from 'chai';
-import {
-  ApprovedItem,
-  CuratedStatus,
-  RejectedCuratedCorpusItem,
-} from '@prisma/client';
+import { CuratedStatus, RejectedCuratedCorpusItem } from '@prisma/client';
 import {
   assertValidSnowplowObjectUpdateEvents,
   getAllSnowplowEvents,
@@ -13,6 +9,7 @@ import {
 } from '../../test/helpers/snowplow';
 import config from '../../config';
 import {
+  ApprovedItem,
   ReviewedCorpusItemEventType,
   ReviewedCorpusItemPayload,
 } from '../types';
@@ -22,6 +19,7 @@ import { tracker } from './tracker';
 import { CuratedCorpusEventEmitter } from '../curatedCorpusEventEmitter';
 import { getUnixTimestamp } from '../../shared/utils';
 import { CorpusItemSource, Topics } from '../../shared/types';
+import { ApprovedItemAuthor } from '../../database/types';
 
 /**
  * Use a simple mock item instead of using DB helpers
@@ -35,6 +33,10 @@ const approvedItem: ApprovedItem = {
   status: CuratedStatus.RECOMMENDATION,
   title: 'Everything you need to know about React',
   excerpt: 'Something here',
+  authors: [
+    { name: 'Jane Austen', sortOrder: 1 },
+    { name: 'Mary Shelley', sortOrder: 2 },
+  ],
   publisher: 'Octopus Publishing House',
   imageUrl: 'https://test.com/image.png',
   language: 'EN',
@@ -93,6 +95,10 @@ function assertValidSnowplowApprovedItemEvents(eventContext) {
         url: approvedItem.url,
         title: approvedItem.title,
         excerpt: approvedItem.excerpt,
+        authors:
+          approvedItem.authors?.map(
+            (author: ApprovedItemAuthor) => author.name
+          ) ?? [],
         image_url: approvedItem.imageUrl,
         language: approvedItem.language,
         topic: approvedItem.topic,

--- a/src/events/snowplow/ReviewedItemSnowplowHandler.ts
+++ b/src/events/snowplow/ReviewedItemSnowplowHandler.ts
@@ -1,9 +1,5 @@
 import { CuratedCorpusSnowplowHandler } from './CuratedCorpusSnowplowHandler';
-import {
-  ApprovedItem,
-  BaseEventData,
-  ReviewedCorpusItemPayload,
-} from '../types';
+import { BaseEventData, ReviewedCorpusItemPayload } from '../types';
 import { buildSelfDescribingEvent, Tracker } from '@snowplow/node-tracker';
 import { SelfDescribingJson } from '@snowplow/tracker-core';
 import config from '../../config';
@@ -18,7 +14,7 @@ import { getUnixTimestamp } from '../../shared/utils';
 import { CuratedStatus, RejectedCuratedCorpusItem } from '@prisma/client';
 import { CuratedCorpusEventEmitter } from '../curatedCorpusEventEmitter';
 import { CorpusItemSource } from '../../shared/types';
-import { ApprovedItemAuthor } from '../../database/types';
+import { ApprovedItem, ApprovedItemAuthor } from '../../database/types';
 
 type CuratedCorpusItemUpdateEvent = Omit<SelfDescribingJson, 'data'> & {
   data: CuratedCorpusItemUpdate;

--- a/src/events/snowplow/ReviewedItemSnowplowHandler.ts
+++ b/src/events/snowplow/ReviewedItemSnowplowHandler.ts
@@ -1,5 +1,9 @@
 import { CuratedCorpusSnowplowHandler } from './CuratedCorpusSnowplowHandler';
-import { BaseEventData, ReviewedCorpusItemPayload } from '../types';
+import {
+  ApprovedItem,
+  BaseEventData,
+  ReviewedCorpusItemPayload,
+} from '../types';
 import { buildSelfDescribingEvent, Tracker } from '@snowplow/node-tracker';
 import { SelfDescribingJson } from '@snowplow/tracker-core';
 import config from '../../config';
@@ -11,13 +15,10 @@ import {
   ReviewedCorpusItem,
 } from './schema';
 import { getUnixTimestamp } from '../../shared/utils';
-import {
-  ApprovedItem,
-  CuratedStatus,
-  RejectedCuratedCorpusItem,
-} from '@prisma/client';
+import { CuratedStatus, RejectedCuratedCorpusItem } from '@prisma/client';
 import { CuratedCorpusEventEmitter } from '../curatedCorpusEventEmitter';
 import { CorpusItemSource } from '../../shared/types';
+import { ApprovedItemAuthor } from '../../database/types';
 
 type CuratedCorpusItemUpdateEvent = Omit<SelfDescribingJson, 'data'> & {
   data: CuratedCorpusItemUpdate;
@@ -138,6 +139,8 @@ export class ReviewedItemSnowplowHandler extends CuratedCorpusSnowplowHandler {
       title: item.title,
       language: item.language,
       excerpt: item.excerpt,
+      authors:
+        item.authors?.map((author: ApprovedItemAuthor) => author.name) ?? [],
       image_url: item.imageUrl,
       is_collection: item.isCollection,
       is_syndicated: item.isSyndicated,

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,6 +1,13 @@
-import { ApprovedItem, RejectedCuratedCorpusItem } from '@prisma/client';
-import { ScheduledItem, CorpusItem } from '../database/types';
-import { ScheduledItem as ScheduledItemModel } from '@prisma/client';
+import {
+  ApprovedItem as ApprovedItemModel,
+  RejectedCuratedCorpusItem,
+  ScheduledItem as ScheduledItemModel,
+} from '@prisma/client';
+import {
+  ApprovedItemAuthor,
+  ScheduledItem,
+  CorpusItem,
+} from '../database/types';
 
 export enum ReviewedCorpusItemEventType {
   ADD_ITEM = 'ADD_ITEM',
@@ -30,6 +37,10 @@ export type BaseEventData = {
   version: string; // semver (e.g. 1.2.33)
 };
 
+export type ApprovedItem = ApprovedItemModel & {
+  authors?: ApprovedItemAuthor[];
+};
+
 // Data for the events that are fired on changes to curated items
 export type ReviewedCorpusItemPayload = {
   reviewedCorpusItem: ApprovedItem | RejectedCuratedCorpusItem;
@@ -50,7 +61,7 @@ export type ScheduledItemEventBusPayload = BaseEventBusPayload &
   Pick<ScheduledItemModel, 'createdBy' | 'scheduledSurfaceGuid'> &
   Pick<
     ApprovedItem,
-    'topic' | 'isSyndicated' | keyof Omit<CorpusItem, 'id' | 'authors'>
+    'topic' | 'isSyndicated' | keyof Omit<CorpusItem, 'id'>
   > & {
     scheduledItemExternalId: string; // externalId of ScheduledItem
     approvedItemExternalId: string; // externalId of ApprovedItem

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,13 +1,8 @@
 import {
-  ApprovedItem as ApprovedItemModel,
   RejectedCuratedCorpusItem,
   ScheduledItem as ScheduledItemModel,
 } from '@prisma/client';
-import {
-  ApprovedItemAuthor,
-  ScheduledItem,
-  CorpusItem,
-} from '../database/types';
+import { ScheduledItem, CorpusItem, ApprovedItem } from '../database/types';
 
 export enum ReviewedCorpusItemEventType {
   ADD_ITEM = 'ADD_ITEM',
@@ -35,10 +30,6 @@ export type BaseEventData = {
   timestamp: number; // epoch time (ms)
   source: string;
   version: string; // semver (e.g. 1.2.33)
-};
-
-export type ApprovedItem = ApprovedItemModel & {
-  authors?: ApprovedItemAuthor[];
 };
 
 // Data for the events that are fired on changes to curated items


### PR DESCRIPTION
## Goal

When going through the doc ticket ([#1422](https://getpocket.atlassian.net/browse/BACK-1422)) and referencing some code changes, I realised the initial updates to Curated Corpus API missed adding the authors to the data we send with Snowplow events. This ticket should fix that, and update relevant tests.

- Now sending names of authors as an array to Snowplow along with other data for reviewed corpus items. Updated tests.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1442