### PR TITLE
fix(authors): Update tests for public query

### DIFF
--- a/src/public/resolvers/queries/ScheduledSurfaceItem.integration.ts
+++ b/src/public/resolvers/queries/ScheduledSurfaceItem.integration.ts
@@ -118,6 +118,7 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       expect(item.corpusItem.url).not.to.be.null;
       expect(item.corpusItem.title).not.to.be.null;
       expect(item.corpusItem.excerpt).not.to.be.null;
+      expect(item.corpusItem.authors).not.to.be.null;
       expect(item.corpusItem.language).not.to.be.null;
       expect(item.corpusItem.imageUrl).not.to.be.null;
       expect(item.corpusItem.publisher).not.to.be.null;

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -24,6 +24,10 @@ export const GET_SCHEDULED_SURFACE_WITH_ITEMS = gql`
           title
           excerpt
           language
+          authors {
+            name
+            sortOrder
+          }
           publisher
           imageUrl
         }


### PR DESCRIPTION
## Goal

This is a _verrry_ small fix to update integration tests for the public query - adding in authors and expecting to receive some data for them.