### PR TITLE
feat(add topic): add topic to public CorpusItem entity

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -60,6 +60,10 @@ type CorpusItem @key(fields: "id") {
     The author names and sort orders associated with this CorpusItem.
     """
     authors: [CorpusItemAuthor!]
+    """
+    The topic associated with the Approved Item.
+    """
+    topic: String
 }
 
 """

--- a/src/database/queries/ScheduledItem.ts
+++ b/src/database/queries/ScheduledItem.ts
@@ -129,6 +129,14 @@ export async function getItemsForScheduledSurface(
         language: scheduledItem.approvedItem.language,
         publisher: scheduledItem.approvedItem.publisher,
         imageUrl: scheduledItem.approvedItem.imageUrl,
+        // so the type definition in /src/database/types has topic as optional,
+        // which typescript resolves as `string | undefined`. however, if the
+        // topic is missing in the db, prisma returns `null` - hence the
+        // nullish coalescing operator below.
+        //
+        // i wonder why typescript won't accept both. is there some deep dark
+        // JS reason? or is it just better practice?
+        topic: scheduledItem.approvedItem.topic ?? undefined,
       },
     };
     return item;

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -160,6 +160,7 @@ export type CorpusItem = {
   language: string;
   publisher: string;
   imageUrl: string;
+  topic?: string;
 };
 
 export type ScheduledSurfaceItem = {

--- a/src/public/resolvers/queries/ScheduledSurfaceItem.integration.ts
+++ b/src/public/resolvers/queries/ScheduledSurfaceItem.integration.ts
@@ -59,6 +59,19 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
           scheduledDate: new Date('2050-01-01').toISOString(),
         });
       }
+
+      // Create a few records without topics (to model backfilled data)
+      for (let i = 0; i < 7; i++) {
+        const approvedItem = await createApprovedItemHelper(db, {
+          title: `Batch 4, Story #${i + 1}`,
+          topic: undefined,
+        });
+        await createScheduledItemHelper(db, {
+          scheduledSurfaceGuid: 'NEW_TAB_DE_DE',
+          approvedItem,
+          scheduledDate: new Date('3030-01-01').toISOString(),
+        });
+      }
     });
 
     it('should return all requested items', async () => {
@@ -71,8 +84,8 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       });
 
       // Good to check this here before we get into actual return values
-      expect(result.errors).to.be.undefined;
-      expect(result.data).not.to.be.null;
+      expect(result.errors).not.to.exist;
+      expect(result.data).to.exist;
 
       expect(result.data?.scheduledSurface.items).to.have.lengthOf(5);
     });
@@ -87,8 +100,8 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
       });
 
       // Good to check this here before we get into actual return values
-      expect(result.errors).to.be.undefined;
-      expect(result.data).not.to.be.null;
+      expect(result.errors).not.to.exist;
+      expect(result.data).to.exist;
 
       expect(result.data?.scheduledSurface.items).to.have.lengthOf(7);
     });
@@ -102,26 +115,43 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
         },
       });
 
-      expect(result.errors).to.be.undefined;
-      expect(result.data).not.to.be.null;
+      expect(result.errors).not.to.exist;
+      expect(result.data).to.exist;
 
       // Let's check the props for the first ScheduledSurfaceItem returned.
       const item = result.data?.scheduledSurface.items[0];
 
       // Scalar properties of the first item
-      expect(item.id).not.to.be.null;
+      expect(item.id).to.exist;
       expect(item.surfaceId).to.equal('NEW_TAB_EN_US');
       expect(item.scheduledDate).to.equal('2025-05-05');
 
-      // The underlying Corpus Item
-      expect(item.corpusItem.id).not.to.be.null;
-      expect(item.corpusItem.url).not.to.be.null;
-      expect(item.corpusItem.title).not.to.be.null;
-      expect(item.corpusItem.excerpt).not.to.be.null;
-      expect(item.corpusItem.authors).not.to.be.null;
-      expect(item.corpusItem.language).not.to.be.null;
-      expect(item.corpusItem.imageUrl).not.to.be.null;
-      expect(item.corpusItem.publisher).not.to.be.null;
+      // The underlying Corpus Items
+      result.data?.scheduledSurface.items.forEach((item) => {
+        expect(item.corpusItem.id).to.exist;
+        expect(item.corpusItem.url).to.exist;
+        expect(item.corpusItem.title).to.exist;
+        expect(item.corpusItem.excerpt).to.exist;
+        expect(item.corpusItem.authors).to.exist;
+        expect(item.corpusItem.language).to.exist;
+        expect(item.corpusItem.imageUrl).to.exist;
+        expect(item.corpusItem.publisher).to.exist;
+        expect(item.corpusItem.topic).to.exist;
+      });
+    });
+
+    it('should return an empty topic when the approved item has no topic', async () => {
+      const result = await server.executeOperation({
+        query: GET_SCHEDULED_SURFACE_WITH_ITEMS,
+        variables: {
+          id: 'NEW_TAB_DE_DE',
+          date: '3030-01-01',
+        },
+      });
+
+      result.data?.scheduledSurface.items.forEach((item) => {
+        expect(item.corpusItem.topic).not.to.exist;
+      });
     });
 
     it('should sort the items by updatedAt asc', async () => {
@@ -153,8 +183,8 @@ describe('queries: ScheduledCuratedCorpusItem', () => {
         },
       });
 
-      expect(result.errors).to.be.undefined;
-      expect(result.data).not.to.be.null;
+      expect(result.errors).not.to.exist;
+      expect(result.data).to.exist;
 
       expect(result.data?.scheduledSurface.items).to.have.lengthOf(0);
     });

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -30,6 +30,7 @@ export const GET_SCHEDULED_SURFACE_WITH_ITEMS = gql`
           }
           publisher
           imageUrl
+          topic
         }
       }
     }


### PR DESCRIPTION
## Goal

add topic to public `CorpusItem` entity in preparation of need by recommendations/data products.

- update chai statements to use our preferred `exists` (but only in the one file i touched i'm not trying to do it all here)

## I'd love feedback/perspectives on:
- `topic` being a string in our graphql schema and not an enum. i personally think this is the right decision at this time, but would like to know if anyone disagrees.

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1452