### PR TITLE
feat(authors): [BACK-1475] Create a custom mutation to add authors to an approved item

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -718,6 +718,20 @@ input UpdateApprovedCorpusItemInput {
 }
 
 """
+Input data for updating an Approved Item's author data.
+"""
+input UpdateApprovedCorpusItemAuthorsInput {
+    """
+    Approved Item ID.
+    """
+    externalId: ID!
+    """
+    A name and sort order for each author.
+    """
+    authors: [CorpusItemAuthorInput!]!
+}
+
+"""
 Input data for rejecting an Approved Item.
 """
 input RejectApprovedCorpusItemInput {
@@ -880,6 +894,13 @@ type Mutation {
     """
     updateApprovedCorpusItem(
         data: UpdateApprovedCorpusItemInput!
+    ): ApprovedCorpusItem!
+
+    """
+    Updates authors for an Approved Item.
+    """
+    updateApprovedCorpusItemAuthors(
+        data: UpdateApprovedCorpusItemAuthorsInput!
     ): ApprovedCorpusItem!
 
     """

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -13,6 +13,7 @@ import {
   importApprovedItem,
   rejectApprovedItem,
   updateApprovedItem,
+  updateApprovedItemAuthors,
   uploadApprovedItemImage,
 } from './mutations/ApprovedItem';
 import { createRejectedItem } from './mutations/RejectedItem';
@@ -94,6 +95,7 @@ export const resolvers = {
     createApprovedCorpusItem: createApprovedItem,
     rejectApprovedCorpusItem: rejectApprovedItem,
     updateApprovedCorpusItem: updateApprovedItem,
+    updateApprovedCorpusItemAuthors: updateApprovedItemAuthors,
     createRejectedCorpusItem: createRejectedItem,
     createScheduledCorpusItem: createScheduledItem,
     deleteScheduledCorpusItem: deleteScheduledItem,

--- a/src/admin/resolvers/mutations/ApprovedItem.auth.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.auth.integration.ts
@@ -1,0 +1,592 @@
+import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
+import {
+  ApprovedItem,
+  ApprovedItemAuthor,
+  CreateApprovedItemInput,
+  RejectApprovedItemInput,
+  UpdateApprovedItemAuthorsInput,
+  UpdateApprovedItemInput,
+} from '../../../database/types';
+import { CuratedStatus } from '@prisma/client';
+import {
+  ACCESS_DENIED_ERROR,
+  CorpusItemSource,
+  MozillaAccessGroup,
+  Topics,
+} from '../../../shared/types';
+import {
+  clearDb,
+  createApprovedItemHelper,
+  getServerWithMockedHeaders,
+} from '../../../test/helpers';
+import { db, getServer } from '../../../test/admin-server';
+import sinon from 'sinon';
+import { ReviewedCorpusItemEventType } from '../../../events/types';
+import {
+  CREATE_APPROVED_ITEM,
+  REJECT_APPROVED_ITEM,
+  UPDATE_APPROVED_ITEM,
+  UPDATE_APPROVED_ITEM_AUTHORS,
+  UPLOAD_APPROVED_ITEM_IMAGE,
+} from './sample-mutations.gql';
+import { expect } from 'chai';
+import { createReadStream, unlinkSync, writeFileSync } from 'fs';
+import { Upload } from 'graphql-upload';
+
+describe('mutations: ApprovedItem - authentication checks', () => {
+  const eventEmitter = new CuratedCorpusEventEmitter();
+
+  // a standard set of inputs for this mutation
+  const input: CreateApprovedItemInput = {
+    prospectId: '123-abc',
+    title: 'Find Out How I Cured My Docker In 2 Days',
+    url: 'https://test.com/docker',
+    excerpt: 'A short summary of what this story is about',
+    authors: [
+      { name: 'Mark Twain', sortOrder: 1 },
+      { name: 'Jane Austen', sortOrder: 2 },
+    ],
+    status: CuratedStatus.CORPUS,
+    imageUrl: 'https://test.com/image.png',
+    language: 'DE',
+    publisher: 'Convective Cloud',
+    topic: Topics.TECHNOLOGY,
+    source: CorpusItemSource.PROSPECT,
+    isCollection: false,
+    isTimeSensitive: true,
+    isSyndicated: false,
+  };
+
+  beforeAll(async () => {
+    await clearDb(db);
+  });
+
+  describe('createApprovedCorpusItem mutation', () => {
+    it('should succeed if user has access to one of scheduled surfaces', async () => {
+      // set up event tracking
+      const eventTracker = sinon.fake();
+      eventEmitter.on(ReviewedCorpusItemEventType.ADD_ITEM, eventTracker);
+
+      // Set up auth headers with access to a single Scheduled Surface
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_ENGB}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers, eventEmitter);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: CREATE_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.errors).to.be.undefined;
+      expect(result.data).not.to.be.null;
+
+      // Expect to see all the input data we supplied in the Approved Item
+      // returned by the mutation
+      expect(result.data?.createApprovedCorpusItem).to.deep.include(input);
+
+      // Check that the ADD_ITEM event was fired successfully:
+      // 1 - Event was fired once!
+      expect(eventTracker.callCount).to.equal(1);
+      // 2 - Event has the right type.
+      expect(await eventTracker.getCall(0).args[0].eventType).to.equal(
+        ReviewedCorpusItemEventType.ADD_ITEM
+      );
+      // 3- Event has the right entity passed to it.
+      expect(
+        await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
+      ).to.equal(result.data?.createApprovedCorpusItem.externalId);
+
+      await server.stop();
+    });
+
+    it('should fail if request headers are not supplied', async () => {
+      // With the default context, the headers are empty
+      const server = getServer(eventEmitter);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: CREATE_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.null;
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+
+    it("should fail if user doesn't have access to any of scheduled surfaces", async () => {
+      // Set up auth headers with access to something irrelevant here, such as collections
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.COLLECTION_CURATOR_FULL}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers, eventEmitter);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: CREATE_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.null;
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+
+    it('should fail optional scheduling if user has no access to relevant scheduled surface', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_DEDE}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers, eventEmitter);
+      await server.start();
+
+      // extra inputs for scheduling - note attempting to schedule onto the US New Tab
+      // while only having access to the German New Tab
+      input.scheduledDate = '2100-01-01';
+      input.scheduledSurfaceGuid = 'NEW_TAB_EN_US';
+
+      const result = await server.executeOperation({
+        query: CREATE_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.null;
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+  });
+
+  describe('updateApprovedCorpusItem mutation', () => {
+    let item: ApprovedItem;
+    let authors: ApprovedItemAuthor[];
+    let input: UpdateApprovedItemInput;
+
+    beforeEach(async () => {
+      item = await createApprovedItemHelper(db, {
+        title: "3 Things Everyone Knows About LEGO That You Don't",
+        status: CuratedStatus.RECOMMENDATION,
+        language: 'EN',
+      });
+
+      // authors from `item` above do not go through graphql and therefore
+      // contain extra info (externalId, approvedItemId). we need to remove
+      // those properties to prepare an authors array for the update `input`
+      // below
+      if (item.authors) {
+        authors =
+          item.authors?.map((author) => ({
+            name: author.name,
+            sortOrder: author.sortOrder,
+          })) ?? [];
+      }
+
+      input = {
+        externalId: item.externalId,
+        title: 'Anything but LEGO',
+        excerpt: 'Updated excerpt',
+        authors,
+        status: CuratedStatus.CORPUS,
+        imageUrl: 'https://test.com/image.png',
+        language: 'DE',
+        publisher: 'Cloud Factory',
+        topic: Topics.BUSINESS,
+        isTimeSensitive: true,
+      };
+    });
+
+    it('should succeed if user has access to one of scheduled surfaces', async () => {
+      // Set up auth headers with access to a single Scheduled Surface
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_ENGB}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers, eventEmitter);
+      await server.start();
+
+      // Set up event tracking
+      const eventTracker = sinon.fake();
+      eventEmitter.on(ReviewedCorpusItemEventType.UPDATE_ITEM, eventTracker);
+
+      const res = await server.executeOperation({
+        query: UPDATE_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(res.errors).to.be.undefined;
+      const data = res.data;
+
+      // External ID should be unchanged
+      expect(data?.updateApprovedCorpusItem.externalId).to.equal(
+        item.externalId
+      );
+
+      // Updated properties should be... updated
+      expect(data?.updateApprovedCorpusItem).to.deep.include(input);
+
+      // The `updatedBy` field should now be the SSO username of the user
+      // who updated this record
+      expect(data?.updateApprovedCorpusItem.updatedBy).to.equal(
+        headers.username
+      );
+
+      // Check that the UPDATE_ITEM event was fired successfully:
+      // 1 - Event was fired once!
+      expect(eventTracker.callCount).to.equal(1);
+      // 2 - Event has the right type.
+      expect(await eventTracker.getCall(0).args[0].eventType).to.equal(
+        ReviewedCorpusItemEventType.UPDATE_ITEM
+      );
+      // 3- Event has the right entity passed to it.
+      expect(
+        await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
+      ).to.equal(data?.updateApprovedCorpusItem.externalId);
+
+      await server.stop();
+    });
+
+    it('should fail if request headers are not supplied', async () => {
+      // With the default context, the headers are empty
+      const server = getServer(eventEmitter);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: UPDATE_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.null;
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+
+    it("should fail if user doesn't have access to any of scheduled surfaces", async () => {
+      // Set up auth headers with access to something irrelevant here, such as collections
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.COLLECTION_CURATOR_FULL}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers, eventEmitter);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: UPDATE_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.null;
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+  });
+
+  describe('updateApprovedCorpusItemAuthors mutation', () => {
+    let item: ApprovedItem;
+    let authors: ApprovedItemAuthor[];
+    let input: UpdateApprovedItemAuthorsInput;
+
+    beforeEach(async () => {
+      item = await createApprovedItemHelper(db, {
+        title: "3 Things Everyone Knows About LEGO That You Don't",
+        status: CuratedStatus.RECOMMENDATION,
+        language: 'EN',
+      });
+
+      authors = [
+        { name: 'Author One', sortOrder: 1 },
+        { name: 'Author Two', sortOrder: 2 },
+      ];
+
+      input = {
+        externalId: item.externalId,
+        authors,
+      };
+    });
+
+    it('should succeed if user has access to one of scheduled surfaces', async () => {
+      // Set up auth headers with access to a single Scheduled Surface
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_ENGB}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers, eventEmitter);
+      await server.start();
+
+      // Set up event tracking
+      const eventTracker = sinon.fake();
+      eventEmitter.on(ReviewedCorpusItemEventType.UPDATE_ITEM, eventTracker);
+
+      const res = await server.executeOperation({
+        query: UPDATE_APPROVED_ITEM_AUTHORS,
+        variables: { data: input },
+      });
+
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(res.errors).not.to.exist;
+      const data = res.data;
+
+      // External ID should be unchanged
+      expect(data?.updateApprovedCorpusItemAuthors.externalId).to.equal(
+        item.externalId
+      );
+
+      // Updated properties should be... updated
+      expect(data?.updateApprovedCorpusItemAuthors.authors).to.deep.equal(
+        input.authors
+      );
+
+      // The `updatedBy` field should now be the SSO username of the user
+      // who updated this record
+      expect(data?.updateApprovedCorpusItemAuthors.updatedBy).to.equal(
+        headers.username
+      );
+
+      // Check that the UPDATE_ITEM event was fired successfully:
+      // 1 - Event was fired once!
+      expect(eventTracker.callCount).to.equal(1);
+      // 2 - Event has the right type.
+      expect(await eventTracker.getCall(0).args[0].eventType).to.equal(
+        ReviewedCorpusItemEventType.UPDATE_ITEM
+      );
+      // 3- Event has the right entity passed to it.
+      expect(
+        await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
+      ).to.equal(data?.updateApprovedCorpusItemAuthors.externalId);
+
+      await server.stop();
+    });
+
+    it('should fail if request headers are not supplied', async () => {
+      // With the default context, the headers are empty
+      const server = getServer(eventEmitter);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: UPDATE_APPROVED_ITEM_AUTHORS,
+        variables: { data: input },
+      });
+
+      expect(result.data).not.to.exist;
+      expect(result.errors).to.exist;
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+
+    it("should fail if user doesn't have access to any of scheduled surfaces", async () => {
+      // Set up auth headers with access to something irrelevant here, such as collections
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.COLLECTION_CURATOR_FULL}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers, eventEmitter);
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: UPDATE_APPROVED_ITEM_AUTHORS,
+        variables: { data: input },
+      });
+
+      expect(result.data).not.to.exist;
+      expect(result.errors).to.exist;
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+  });
+
+  describe('rejectApprovedItem mutation', () => {
+    it('should successfully reject an approved item when the user has access to at least one scheduled surface', async () => {
+      // Set up auth headers with access to a single Scheduled Surface
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_ENGB}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+      await server.start();
+
+      const item = await createApprovedItemHelper(db, {
+        title: '15 Unheard Ways To Achieve Greater Terraform',
+        status: CuratedStatus.RECOMMENDATION,
+        language: 'EN',
+      });
+
+      const input: RejectApprovedItemInput = {
+        externalId: item.externalId,
+        reason: 'MISINFORMATION,OTHER',
+      };
+
+      const result = await server.executeOperation({
+        query: REJECT_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.errors).to.be.undefined;
+      expect(result.data).not.to.be.null;
+
+      // On success, mutation should return the deleted approved item.
+      // Let's verify the id.
+      expect(result.data?.rejectApprovedCorpusItem.externalId).to.equal(
+        item.externalId
+      );
+
+      await server.stop();
+    });
+
+    it('should throw an error when the user has no access any scheduled surface', async () => {
+      // Set up auth headers without access to any Scheduled Surface
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+      await server.start();
+
+      const input: RejectApprovedItemInput = {
+        externalId: 'test-id',
+        reason: 'MISINFORMATION,OTHER',
+      };
+
+      const result = await server.executeOperation({
+        query: REJECT_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.errors).not.to.be.undefined;
+      expect(result.data).to.be.null;
+
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+
+    it('should throw an error when the user has only read-only access', async () => {
+      // Set up auth headers with read-only access
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,${MozillaAccessGroup.READONLY}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+      await server.start();
+
+      const input: RejectApprovedItemInput = {
+        externalId: 'test-id',
+        reason: 'MISINFORMATION,OTHER',
+      };
+
+      const result = await server.executeOperation({
+        query: REJECT_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.errors).not.to.be.undefined;
+      expect(result.data).to.be.null;
+
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+
+    it('should throw an error when the request headers are undefined', async () => {
+      // pass in empty object for headers
+      const server = getServerWithMockedHeaders({});
+      await server.start();
+
+      const input: RejectApprovedItemInput = {
+        externalId: 'test-id',
+        reason: 'MISINFORMATION,OTHER',
+      };
+
+      const result = await server.executeOperation({
+        query: REJECT_APPROVED_ITEM,
+        variables: { data: input },
+      });
+
+      expect(result.errors).not.to.be.undefined;
+      expect(result.data).to.be.null;
+
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+  });
+
+  describe('uploadApprovedCuratedCorpusItemImage mutation', () => {
+    const testFilePath = __dirname + '/test-image.jpeg';
+
+    beforeEach(() => {
+      writeFileSync(testFilePath, 'I am an image');
+    });
+
+    afterEach(() => {
+      unlinkSync(testFilePath);
+    });
+
+    it('should not succeed if user does not have write to corpus privileges', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.READONLY}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+      await server.start();
+
+      const image: Upload = new Upload();
+
+      image.resolve({
+        filename: 'test.jpg',
+        mimetype: 'image/jpeg',
+        encoding: '7bit',
+        createReadStream: () => createReadStream(testFilePath),
+      });
+
+      const result = await server.executeOperation({
+        query: UPLOAD_APPROVED_ITEM_IMAGE,
+        variables: {
+          image: image,
+        },
+      });
+
+      expect(result.data).to.be.null;
+      expect(result.errors).not.to.be.null;
+      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+  });
+});

--- a/src/admin/resolvers/mutations/ApprovedItem.auth.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.auth.integration.ts
@@ -20,8 +20,6 @@ import {
   getServerWithMockedHeaders,
 } from '../../../test/helpers';
 import { db, getServer } from '../../../test/admin-server';
-import sinon from 'sinon';
-import { ReviewedCorpusItemEventType } from '../../../events/types';
 import {
   CREATE_APPROVED_ITEM,
   REJECT_APPROVED_ITEM,
@@ -63,10 +61,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
 
   describe('createApprovedCorpusItem mutation', () => {
     it('should succeed if user has access to one of scheduled surfaces', async () => {
-      // set up event tracking
-      const eventTracker = sinon.fake();
-      eventEmitter.on(ReviewedCorpusItemEventType.ADD_ITEM, eventTracker);
-
       // Set up auth headers with access to a single Scheduled Surface
       const headers = {
         name: 'Test User',
@@ -75,7 +69,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       };
 
       const server = getServerWithMockedHeaders(headers, eventEmitter);
-      await server.start();
 
       const result = await server.executeOperation({
         query: CREATE_APPROVED_ITEM,
@@ -88,26 +81,11 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       // Expect to see all the input data we supplied in the Approved Item
       // returned by the mutation
       expect(result.data?.createApprovedCorpusItem).to.deep.include(input);
-
-      // Check that the ADD_ITEM event was fired successfully:
-      // 1 - Event was fired once!
-      expect(eventTracker.callCount).to.equal(1);
-      // 2 - Event has the right type.
-      expect(await eventTracker.getCall(0).args[0].eventType).to.equal(
-        ReviewedCorpusItemEventType.ADD_ITEM
-      );
-      // 3- Event has the right entity passed to it.
-      expect(
-        await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(result.data?.createApprovedCorpusItem.externalId);
-
-      await server.stop();
     });
 
     it('should fail if request headers are not supplied', async () => {
       // With the default context, the headers are empty
       const server = getServer(eventEmitter);
-      await server.start();
 
       const result = await server.executeOperation({
         query: CREATE_APPROVED_ITEM,
@@ -117,8 +95,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.data).to.be.null;
       expect(result.errors).not.to.be.null;
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
 
     it("should fail if user doesn't have access to any of scheduled surfaces", async () => {
@@ -130,7 +106,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       };
 
       const server = getServerWithMockedHeaders(headers, eventEmitter);
-      await server.start();
 
       const result = await server.executeOperation({
         query: CREATE_APPROVED_ITEM,
@@ -140,8 +115,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.data).to.be.null;
       expect(result.errors).not.to.be.null;
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
 
     it('should fail optional scheduling if user has no access to relevant scheduled surface', async () => {
@@ -152,7 +125,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       };
 
       const server = getServerWithMockedHeaders(headers, eventEmitter);
-      await server.start();
 
       // extra inputs for scheduling - note attempting to schedule onto the US New Tab
       // while only having access to the German New Tab
@@ -167,8 +139,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.data).to.be.null;
       expect(result.errors).not.to.be.null;
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
   });
 
@@ -219,11 +189,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       };
 
       const server = getServerWithMockedHeaders(headers, eventEmitter);
-      await server.start();
-
-      // Set up event tracking
-      const eventTracker = sinon.fake();
-      eventEmitter.on(ReviewedCorpusItemEventType.UPDATE_ITEM, eventTracker);
 
       const res = await server.executeOperation({
         query: UPDATE_APPROVED_ITEM,
@@ -247,26 +212,11 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(data?.updateApprovedCorpusItem.updatedBy).to.equal(
         headers.username
       );
-
-      // Check that the UPDATE_ITEM event was fired successfully:
-      // 1 - Event was fired once!
-      expect(eventTracker.callCount).to.equal(1);
-      // 2 - Event has the right type.
-      expect(await eventTracker.getCall(0).args[0].eventType).to.equal(
-        ReviewedCorpusItemEventType.UPDATE_ITEM
-      );
-      // 3- Event has the right entity passed to it.
-      expect(
-        await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(data?.updateApprovedCorpusItem.externalId);
-
-      await server.stop();
     });
 
     it('should fail if request headers are not supplied', async () => {
       // With the default context, the headers are empty
       const server = getServer(eventEmitter);
-      await server.start();
 
       const result = await server.executeOperation({
         query: UPDATE_APPROVED_ITEM,
@@ -276,8 +226,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.data).to.be.null;
       expect(result.errors).not.to.be.null;
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
 
     it("should fail if user doesn't have access to any of scheduled surfaces", async () => {
@@ -289,7 +237,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       };
 
       const server = getServerWithMockedHeaders(headers, eventEmitter);
-      await server.start();
 
       const result = await server.executeOperation({
         query: UPDATE_APPROVED_ITEM,
@@ -299,8 +246,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.data).to.be.null;
       expect(result.errors).not.to.be.null;
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
   });
 
@@ -336,11 +281,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       };
 
       const server = getServerWithMockedHeaders(headers, eventEmitter);
-      await server.start();
-
-      // Set up event tracking
-      const eventTracker = sinon.fake();
-      eventEmitter.on(ReviewedCorpusItemEventType.UPDATE_ITEM, eventTracker);
 
       const res = await server.executeOperation({
         query: UPDATE_APPROVED_ITEM_AUTHORS,
@@ -366,26 +306,11 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(data?.updateApprovedCorpusItemAuthors.updatedBy).to.equal(
         headers.username
       );
-
-      // Check that the UPDATE_ITEM event was fired successfully:
-      // 1 - Event was fired once!
-      expect(eventTracker.callCount).to.equal(1);
-      // 2 - Event has the right type.
-      expect(await eventTracker.getCall(0).args[0].eventType).to.equal(
-        ReviewedCorpusItemEventType.UPDATE_ITEM
-      );
-      // 3- Event has the right entity passed to it.
-      expect(
-        await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(data?.updateApprovedCorpusItemAuthors.externalId);
-
-      await server.stop();
     });
 
     it('should fail if request headers are not supplied', async () => {
       // With the default context, the headers are empty
       const server = getServer(eventEmitter);
-      await server.start();
 
       const result = await server.executeOperation({
         query: UPDATE_APPROVED_ITEM_AUTHORS,
@@ -395,8 +320,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.data).not.to.exist;
       expect(result.errors).to.exist;
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
 
     it("should fail if user doesn't have access to any of scheduled surfaces", async () => {
@@ -408,7 +331,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       };
 
       const server = getServerWithMockedHeaders(headers, eventEmitter);
-      await server.start();
 
       const result = await server.executeOperation({
         query: UPDATE_APPROVED_ITEM_AUTHORS,
@@ -418,8 +340,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.data).not.to.exist;
       expect(result.errors).to.exist;
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
   });
 
@@ -433,7 +353,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const item = await createApprovedItemHelper(db, {
         title: '15 Unheard Ways To Achieve Greater Terraform',
@@ -459,8 +378,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.data?.rejectApprovedCorpusItem.externalId).to.equal(
         item.externalId
       );
-
-      await server.stop();
     });
 
     it('should throw an error when the user has no access any scheduled surface', async () => {
@@ -472,7 +389,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const input: RejectApprovedItemInput = {
         externalId: 'test-id',
@@ -488,8 +404,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.data).to.be.null;
 
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
 
     it('should throw an error when the user has only read-only access', async () => {
@@ -501,7 +415,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const input: RejectApprovedItemInput = {
         externalId: 'test-id',
@@ -517,14 +430,11 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.data).to.be.null;
 
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
 
     it('should throw an error when the request headers are undefined', async () => {
       // pass in empty object for headers
       const server = getServerWithMockedHeaders({});
-      await server.start();
 
       const input: RejectApprovedItemInput = {
         externalId: 'test-id',
@@ -540,8 +450,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.data).to.be.null;
 
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
   });
 
@@ -564,7 +472,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       };
 
       const server = getServerWithMockedHeaders(headers);
-      await server.start();
 
       const image: Upload = new Upload();
 
@@ -585,8 +492,6 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.data).to.be.null;
       expect(result.errors).not.to.be.null;
       expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
   });
 });

--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -2,7 +2,7 @@ import config from '../../../config';
 import { CuratedStatus } from '@prisma/client';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { db, getServer } from '../../../test/admin-server';
+import { db } from '../../../test/admin-server';
 import {
   clearDb,
   createApprovedItemHelper,
@@ -35,7 +35,6 @@ import { Upload } from 'graphql-upload';
 import { createReadStream, unlinkSync, writeFileSync } from 'fs';
 import { GET_REJECTED_ITEMS } from '../queries/sample-queries.gql';
 import {
-  ACCESS_DENIED_ERROR,
   CorpusItemSource,
   MozillaAccessGroup,
   Topics,

--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -53,13 +53,8 @@ describe('mutations: ApprovedItem', () => {
 
   const server = getServerWithMockedHeaders(headers, eventEmitter);
 
-  beforeAll(async () => {
-    await server.start();
-  });
-
   afterAll(async () => {
     await db.$disconnect();
-    await server.stop();
   });
 
   beforeEach(async () => {
@@ -421,7 +416,7 @@ describe('mutations: ApprovedItem', () => {
       };
     });
 
-    it('should succeed if user has full access', async () => {
+    it('should succeed on the happy path (full access, valid input)', async () => {
       // Set up event tracking
       const eventTracker = sinon.fake();
       eventEmitter.on(ReviewedCorpusItemEventType.UPDATE_ITEM, eventTracker);

--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -15,6 +15,7 @@ import {
   IMPORT_APPROVED_ITEM,
   REJECT_APPROVED_ITEM,
   UPDATE_APPROVED_ITEM,
+  UPDATE_APPROVED_ITEM_AUTHORS,
   UPLOAD_APPROVED_ITEM_IMAGE,
 } from './sample-mutations.gql';
 import {
@@ -22,6 +23,7 @@ import {
   ApprovedItemAuthor,
   CreateApprovedItemInput,
   RejectApprovedItemInput,
+  UpdateApprovedItemAuthorsInput,
   UpdateApprovedItemInput,
 } from '../../../database/types';
 import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
@@ -461,99 +463,6 @@ describe('mutations: ApprovedItem', () => {
       ).to.equal(data?.updateApprovedCorpusItem.externalId);
     });
 
-    it('should succeed if user has access to one of scheduled surfaces', async () => {
-      // Set up auth headers with access to a single Scheduled Surface
-      const headers = {
-        name: 'Test User',
-        username: 'test.user@test.com',
-        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_ENGB}`,
-      };
-
-      const server = getServerWithMockedHeaders(headers, eventEmitter);
-      await server.start();
-
-      // Set up event tracking
-      const eventTracker = sinon.fake();
-      eventEmitter.on(ReviewedCorpusItemEventType.UPDATE_ITEM, eventTracker);
-
-      const res = await server.executeOperation({
-        query: UPDATE_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      // Good to check for any errors before proceeding with the rest of the test
-      expect(res.errors).to.be.undefined;
-      const data = res.data;
-
-      // External ID should be unchanged
-      expect(data?.updateApprovedCorpusItem.externalId).to.equal(
-        item.externalId
-      );
-
-      // Updated properties should be... updated
-      expect(data?.updateApprovedCorpusItem).to.deep.include(input);
-
-      // The `updatedBy` field should now be the SSO username of the user
-      // who updated this record
-      expect(data?.updateApprovedCorpusItem.updatedBy).to.equal(
-        headers.username
-      );
-
-      // Check that the UPDATE_ITEM event was fired successfully:
-      // 1 - Event was fired once!
-      expect(eventTracker.callCount).to.equal(1);
-      // 2 - Event has the right type.
-      expect(await eventTracker.getCall(0).args[0].eventType).to.equal(
-        ReviewedCorpusItemEventType.UPDATE_ITEM
-      );
-      // 3- Event has the right entity passed to it.
-      expect(
-        await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(data?.updateApprovedCorpusItem.externalId);
-
-      await server.stop();
-    });
-
-    it('should fail if request headers are not supplied', async () => {
-      // With the default context, the headers are empty
-      const server = getServer(eventEmitter);
-      await server.start();
-
-      const result = await server.executeOperation({
-        query: UPDATE_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      expect(result.data).to.be.null;
-      expect(result.errors).not.to.be.null;
-      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
-    });
-
-    it("should fail if user doesn't have access to any of scheduled surfaces", async () => {
-      // Set up auth headers with access to something irrelevant here, such as collections
-      const headers = {
-        name: 'Test User',
-        username: 'test.user@test.com',
-        groups: `group1,group2,${MozillaAccessGroup.COLLECTION_CURATOR_FULL}`,
-      };
-
-      const server = getServerWithMockedHeaders(headers, eventEmitter);
-      await server.start();
-
-      const result = await server.executeOperation({
-        query: UPDATE_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      expect(result.data).to.be.null;
-      expect(result.errors).not.to.be.null;
-      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
-    });
-
     it('should fail if sent an invalid topic', async () => {
       // this should be `HEALTH_FITNESS`
       input.topic = 'HEALTH FITNESS';
@@ -605,6 +514,73 @@ describe('mutations: ApprovedItem', () => {
       expect(result.errors?.[0].message).to.contain(
         'does not exist in "CorpusLanguage" enum.'
       );
+    });
+  });
+
+  describe('updateApprovedCorpusAuthorsItem mutation', () => {
+    let item: ApprovedItem;
+    let authors: ApprovedItemAuthor[];
+    let input: UpdateApprovedItemAuthorsInput;
+
+    beforeEach(async () => {
+      item = await createApprovedItemHelper(db, {
+        title: "3 Things Everyone Knows About LEGO That You Don't",
+        status: CuratedStatus.RECOMMENDATION,
+        language: 'EN',
+      });
+
+      authors = [
+        { name: 'Author One', sortOrder: 1 },
+        { name: 'Author Two', sortOrder: 2 },
+      ];
+
+      input = {
+        externalId: item.externalId,
+        authors,
+      };
+    });
+
+    it('should succeed if user has full access', async () => {
+      // Set up event tracking
+      const eventTracker = sinon.fake();
+      eventEmitter.on(ReviewedCorpusItemEventType.UPDATE_ITEM, eventTracker);
+
+      const res = await server.executeOperation({
+        query: UPDATE_APPROVED_ITEM_AUTHORS,
+        variables: { data: input },
+      });
+
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(res.errors).not.to.exist;
+      const data = res.data;
+
+      // External ID should be unchanged
+      expect(data?.updateApprovedCorpusItemAuthors.externalId).to.equal(
+        item.externalId
+      );
+
+      // Updated properties should be... updated
+      expect(data?.updateApprovedCorpusItemAuthors.authors).to.deep.equal(
+        input.authors
+      );
+
+      // The `updatedBy` field should now be the SSO username of the user
+      // who updated this record
+      expect(data?.updateApprovedCorpusItemAuthors.updatedBy).to.equal(
+        headers.username
+      );
+
+      // Check that the UPDATE_ITEM event was fired successfully:
+      // 1 - Event was fired once!
+      expect(eventTracker.callCount).to.equal(1);
+      // 2 - Event has the right type.
+      expect(await eventTracker.getCall(0).args[0].eventType).to.equal(
+        ReviewedCorpusItemEventType.UPDATE_ITEM
+      );
+      // 3- Event has the right entity passed to it.
+      expect(
+        await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
+      ).to.equal(data?.updateApprovedCorpusItemAuthors.externalId);
     });
   });
 
@@ -1087,313 +1063,6 @@ describe('mutations: ApprovedItem', () => {
       );
       // Check that the ADD_SCHEDULE event was not fired
       expect(addScheduleEventTracker.callCount).to.equal(0);
-    });
-  });
-});
-
-describe('mutations: ApprovedItem - authentication checks', () => {
-  const eventEmitter = new CuratedCorpusEventEmitter();
-
-  // a standard set of inputs for this mutation
-  const input: CreateApprovedItemInput = {
-    prospectId: '123-abc',
-    title: 'Find Out How I Cured My Docker In 2 Days',
-    url: 'https://test.com/docker',
-    excerpt: 'A short summary of what this story is about',
-    authors: [
-      { name: 'Mark Twain', sortOrder: 1 },
-      { name: 'Jane Austen', sortOrder: 2 },
-    ],
-    status: CuratedStatus.CORPUS,
-    imageUrl: 'https://test.com/image.png',
-    language: 'DE',
-    publisher: 'Convective Cloud',
-    topic: Topics.TECHNOLOGY,
-    source: CorpusItemSource.PROSPECT,
-    isCollection: false,
-    isTimeSensitive: true,
-    isSyndicated: false,
-  };
-
-  beforeAll(async () => {
-    await clearDb(db);
-  });
-
-  describe('createApprovedCorpusItem mutation', () => {
-    it('should succeed if user has access to one of scheduled surfaces', async () => {
-      // set up event tracking
-      const eventTracker = sinon.fake();
-      eventEmitter.on(ReviewedCorpusItemEventType.ADD_ITEM, eventTracker);
-
-      // Set up auth headers with access to a single Scheduled Surface
-      const headers = {
-        name: 'Test User',
-        username: 'test.user@test.com',
-        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_ENGB}`,
-      };
-
-      const server = getServerWithMockedHeaders(headers, eventEmitter);
-      await server.start();
-
-      const result = await server.executeOperation({
-        query: CREATE_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      expect(result.errors).to.be.undefined;
-      expect(result.data).not.to.be.null;
-
-      // Expect to see all the input data we supplied in the Approved Item
-      // returned by the mutation
-      expect(result.data?.createApprovedCorpusItem).to.deep.include(input);
-
-      // Check that the ADD_ITEM event was fired successfully:
-      // 1 - Event was fired once!
-      expect(eventTracker.callCount).to.equal(1);
-      // 2 - Event has the right type.
-      expect(await eventTracker.getCall(0).args[0].eventType).to.equal(
-        ReviewedCorpusItemEventType.ADD_ITEM
-      );
-      // 3- Event has the right entity passed to it.
-      expect(
-        await eventTracker.getCall(0).args[0].reviewedCorpusItem.externalId
-      ).to.equal(result.data?.createApprovedCorpusItem.externalId);
-
-      await server.stop();
-    });
-
-    it('should fail if request headers are not supplied', async () => {
-      // With the default context, the headers are empty
-      const server = getServer(eventEmitter);
-      await server.start();
-
-      const result = await server.executeOperation({
-        query: CREATE_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      expect(result.data).to.be.null;
-      expect(result.errors).not.to.be.null;
-      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
-    });
-
-    it("should fail if user doesn't have access to any of scheduled surfaces", async () => {
-      // Set up auth headers with access to something irrelevant here, such as collections
-      const headers = {
-        name: 'Test User',
-        username: 'test.user@test.com',
-        groups: `group1,group2,${MozillaAccessGroup.COLLECTION_CURATOR_FULL}`,
-      };
-
-      const server = getServerWithMockedHeaders(headers, eventEmitter);
-      await server.start();
-
-      const result = await server.executeOperation({
-        query: CREATE_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      expect(result.data).to.be.null;
-      expect(result.errors).not.to.be.null;
-      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
-    });
-
-    it('should fail optional scheduling if user has no access to relevant scheduled surface', async () => {
-      const headers = {
-        name: 'Test User',
-        username: 'test.user@test.com',
-        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_DEDE}`,
-      };
-
-      const server = getServerWithMockedHeaders(headers, eventEmitter);
-      await server.start();
-
-      // extra inputs for scheduling - note attempting to schedule onto the US New Tab
-      // while only having access to the German New Tab
-      input.scheduledDate = '2100-01-01';
-      input.scheduledSurfaceGuid = 'NEW_TAB_EN_US';
-
-      const result = await server.executeOperation({
-        query: CREATE_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      expect(result.data).to.be.null;
-      expect(result.errors).not.to.be.null;
-      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
-    });
-  });
-
-  describe('rejectApprovedItem mutation', () => {
-    it('should successfully reject an approved item when the user has access to at least one scheduled surface', async () => {
-      // Set up auth headers with access to a single Scheduled Surface
-      const headers = {
-        name: 'Test User',
-        username: 'test.user@test.com',
-        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_ENGB}`,
-      };
-
-      const server = getServerWithMockedHeaders(headers);
-      await server.start();
-
-      const item = await createApprovedItemHelper(db, {
-        title: '15 Unheard Ways To Achieve Greater Terraform',
-        status: CuratedStatus.RECOMMENDATION,
-        language: 'EN',
-      });
-
-      const input: RejectApprovedItemInput = {
-        externalId: item.externalId,
-        reason: 'MISINFORMATION,OTHER',
-      };
-
-      const result = await server.executeOperation({
-        query: REJECT_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      expect(result.errors).to.be.undefined;
-      expect(result.data).not.to.be.null;
-
-      // On success, mutation should return the deleted approved item.
-      // Let's verify the id.
-      expect(result.data?.rejectApprovedCorpusItem.externalId).to.equal(
-        item.externalId
-      );
-
-      await server.stop();
-    });
-
-    it('should throw an error when the user has no access any scheduled surface', async () => {
-      // Set up auth headers without access to any Scheduled Surface
-      const headers = {
-        name: 'Test User',
-        username: 'test.user@test.com',
-        groups: `group1,group2`,
-      };
-
-      const server = getServerWithMockedHeaders(headers);
-      await server.start();
-
-      const input: RejectApprovedItemInput = {
-        externalId: 'test-id',
-        reason: 'MISINFORMATION,OTHER',
-      };
-
-      const result = await server.executeOperation({
-        query: REJECT_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      expect(result.errors).not.to.be.undefined;
-      expect(result.data).to.be.null;
-
-      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
-    });
-
-    it('should throw an error when the user has only read-only access', async () => {
-      // Set up auth headers with read-only access
-      const headers = {
-        name: 'Test User',
-        username: 'test.user@test.com',
-        groups: `group1,${MozillaAccessGroup.READONLY}`,
-      };
-
-      const server = getServerWithMockedHeaders(headers);
-      await server.start();
-
-      const input: RejectApprovedItemInput = {
-        externalId: 'test-id',
-        reason: 'MISINFORMATION,OTHER',
-      };
-
-      const result = await server.executeOperation({
-        query: REJECT_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      expect(result.errors).not.to.be.undefined;
-      expect(result.data).to.be.null;
-
-      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
-    });
-
-    it('should throw an error when the request headers are undefined', async () => {
-      // pass in empty object for headers
-      const server = getServerWithMockedHeaders({});
-      await server.start();
-
-      const input: RejectApprovedItemInput = {
-        externalId: 'test-id',
-        reason: 'MISINFORMATION,OTHER',
-      };
-
-      const result = await server.executeOperation({
-        query: REJECT_APPROVED_ITEM,
-        variables: { data: input },
-      });
-
-      expect(result.errors).not.to.be.undefined;
-      expect(result.data).to.be.null;
-
-      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
-    });
-  });
-
-  describe('uploadApprovedCuratedCorpusItemImage mutation', () => {
-    const testFilePath = __dirname + '/test-image.jpeg';
-
-    beforeEach(() => {
-      writeFileSync(testFilePath, 'I am an image');
-    });
-
-    afterEach(() => {
-      unlinkSync(testFilePath);
-    });
-
-    it('should not succeed if user does not have write to corpus privileges', async () => {
-      const headers = {
-        name: 'Test User',
-        username: 'test.user@test.com',
-        groups: `group1,group2,${MozillaAccessGroup.READONLY}`,
-      };
-
-      const server = getServerWithMockedHeaders(headers);
-      await server.start();
-
-      const image: Upload = new Upload();
-
-      image.resolve({
-        filename: 'test.jpg',
-        mimetype: 'image/jpeg',
-        encoding: '7bit',
-        createReadStream: () => createReadStream(testFilePath),
-      });
-
-      const result = await server.executeOperation({
-        query: UPLOAD_APPROVED_ITEM_IMAGE,
-        variables: {
-          image: image,
-        },
-      });
-
-      expect(result.data).to.be.null;
-      expect(result.errors).not.to.be.null;
-      expect(result.errors?.[0].message).to.contain(ACCESS_DENIED_ERROR);
-
-      await server.stop();
     });
   });
 });

--- a/src/admin/resolvers/mutations/ApprovedItem.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.ts
@@ -155,13 +155,11 @@ export async function updateApprovedItem(
   );
 
   // Remove the old author(s) from the DB records before we run the update function
-  if (existingItem) {
-    await context.db.approvedItemAuthor.deleteMany({
-      where: {
-        approvedItemId: existingItem.id,
-      },
-    });
-  }
+  await context.db.approvedItemAuthor.deleteMany({
+    where: {
+      approvedItemId: existingItem?.id,
+    },
+  });
 
   // Update the corpus item with the updated fields sent through, including
   // any authors.
@@ -207,13 +205,11 @@ export async function updateApprovedItemAuthors(
   // Remove the old author(s) from the DB records before we run the update function
   // Note that we don't expect any authors to be present for any items this mutation
   // will be run for, but it's a good idea to be thorough anyway.
-  if (existingItem) {
-    await context.db.approvedItemAuthor.deleteMany({
-      where: {
-        approvedItemId: existingItem.id,
-      },
-    });
-  }
+  await context.db.approvedItemAuthor.deleteMany({
+    where: {
+      approvedItemId: existingItem?.id,
+    },
+  });
 
   // Update the corpus item with the updated fields sent through, including
   // any authors.

--- a/src/admin/resolvers/mutations/ApprovedItem.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.ts
@@ -8,6 +8,7 @@ import {
   importApprovedItem as dbImportApprovedItem,
   importScheduledItem,
   updateApprovedItem as dbUpdateApprovedItem,
+  updateApprovedItemAuthors as dbUpdateApprovedItemAuthors,
 } from '../../../database/mutations';
 import { getApprovedItemByUrl } from '../../../database/queries';
 import {
@@ -170,6 +171,59 @@ export async function updateApprovedItem(
     context.authenticatedUser.username
   );
 
+  context.emitReviewedCorpusItemEvent(
+    ReviewedCorpusItemEventType.UPDATE_ITEM,
+    approvedItem
+  );
+
+  return approvedItem;
+}
+
+/**
+ * A targeted update operation that only updates an approved item's authors data.
+ * Used to backfill authors for legacy curated items.
+ *
+ * @param parent
+ * @param data
+ * @param context
+ */
+export async function updateApprovedItemAuthors(
+  parent,
+  { data },
+  context: IContext
+): Promise<ApprovedItem> {
+  // Check if the user can perform this mutation
+  if (!context.authenticatedUser.canWriteToCorpus()) {
+    throw new AuthenticationError(ACCESS_DENIED_ERROR);
+  }
+  // To be able to delete authors associated with a corpus item, we first need
+  // to get the internal (integer) id for the story. This means doing a DB query
+  // to fetch the entire object.
+  const existingItem = await getApprovedItemByExternalId(
+    context.db,
+    data.externalId
+  );
+
+  // Remove the old author(s) from the DB records before we run the update function
+  // Note that we don't expect any authors to be present for any items this mutation
+  // will be run for, but it's a good idea to be thorough anyway.
+  if (existingItem) {
+    await context.db.approvedItemAuthor.deleteMany({
+      where: {
+        approvedItemId: existingItem.id,
+      },
+    });
+  }
+
+  // Update the corpus item with the updated fields sent through, including
+  // any authors.
+  const approvedItem = await dbUpdateApprovedItemAuthors(
+    context.db,
+    data,
+    context.authenticatedUser.username
+  );
+
+  // Emit the update item event
   context.emitReviewedCorpusItemEvent(
     ReviewedCorpusItemEventType.UPDATE_ITEM,
     approvedItem

--- a/src/admin/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/admin/resolvers/mutations/sample-mutations.gql.ts
@@ -27,6 +27,17 @@ export const UPDATE_APPROVED_ITEM = gql`
   ${CuratedItemData}
 `;
 
+export const UPDATE_APPROVED_ITEM_AUTHORS = gql`
+  mutation updateApprovedCorpusItemAuthors(
+    $data: UpdateApprovedCorpusItemAuthorsInput!
+  ) {
+    updateApprovedCorpusItemAuthors(data: $data) {
+      ...CuratedItemData
+    }
+  }
+  ${CuratedItemData}
+`;
+
 export const REJECT_APPROVED_ITEM = gql`
   mutation rejectApprovedItem($data: RejectApprovedCorpusItemInput!) {
     rejectApprovedCorpusItem(data: $data) {

--- a/src/database/mutations/ApprovedItem.ts
+++ b/src/database/mutations/ApprovedItem.ts
@@ -2,6 +2,7 @@ import { ApprovedItem, PrismaClient } from '@prisma/client';
 import {
   CreateApprovedItemInput,
   ImportApprovedItemInput,
+  UpdateApprovedItemAuthorsInput,
   UpdateApprovedItemInput,
 } from '../types';
 import { ApolloError, UserInputError } from 'apollo-server-errors';
@@ -76,7 +77,41 @@ export async function updateApprovedItem(
       ...data,
       // Use the SSO username here.
       updatedBy: username,
-      // Authors are stored in its own table, so need to have a nested `create`.
+      // Authors are stored in their own table, so need to have a nested `create`.
+      authors: {
+        create: data.authors,
+      },
+    },
+    include: {
+      authors: {
+        orderBy: [{ sortOrder: 'asc' }],
+      },
+    },
+  });
+}
+
+/**
+ * A targeted update operation that only updates an approved item's authors data.
+ * Used to backfill authors for legacy curated items.
+ *
+ * @param db
+ * @param data
+ * @param username
+ */
+export async function updateApprovedItemAuthors(
+  db: PrismaClient,
+  data: UpdateApprovedItemAuthorsInput,
+  username: string
+): Promise<ApprovedItem> {
+  if (!data.externalId) {
+    throw new UserInputError('externalId must be provided.');
+  }
+  return db.approvedItem.update({
+    where: { externalId: data.externalId },
+    data: {
+      // Use the SSO username here.
+      updatedBy: username,
+      // Authors are stored in their own table, so need to have a nested `create`.
       authors: {
         create: data.authors,
       },

--- a/src/database/mutations/index.ts
+++ b/src/database/mutations/index.ts
@@ -2,6 +2,7 @@ export {
   createApprovedItem,
   deleteApprovedItem,
   updateApprovedItem,
+  updateApprovedItemAuthors,
   importApprovedItem,
 } from './ApprovedItem';
 export { createRejectedItem } from './RejectedItem';

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -97,6 +97,11 @@ export type UpdateApprovedItemInput = Omit<
   externalId: string;
 };
 
+export type UpdateApprovedItemAuthorsInput = {
+  externalId: string;
+  authors: ApprovedItemAuthor[];
+};
+
 export type RejectApprovedItemInput = {
   externalId: string;
   reason: string;


### PR DESCRIPTION
## Goal

Facilitate backfilling author information in the curated corpus. Initially we thought we could use the `updateApprovedCorpusItem` mutation, but that one requires `topic` to be set, which is something that many `DE` items don't yet have. So a custom mutation is needed, and it might as well take in only the data it actually needs rather than all editable fields of a curated item.

- [x] Added a new mutation, `updateApprovedCorpusItemAuthors`, that takes in `externalId` and `authors` object, then updates the approved corpus item.
- [x] Added tests.

Note that a whole bunch of + X lines there, -Y lines here is me splitting out auth-related integration tests for approved items into their own file. 

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1475