### PR TITLE
feat(resolvers): [HS-32] Resolve CorpusItem

### DIFF
--- a/src/database/queries/ApprovedItem.ts
+++ b/src/database/queries/ApprovedItem.ts
@@ -115,6 +115,11 @@ export async function getApprovedItemByExternalId(
 ): Promise<ApprovedItem | null> {
   return db.approvedItem.findUnique({
     where: { externalId },
+    include: {
+      authors: {
+        orderBy: [{ sortOrder: 'asc' }],
+      },
+    },
   });
 }
 

--- a/src/database/queries/ScheduledItem.ts
+++ b/src/database/queries/ScheduledItem.ts
@@ -6,7 +6,10 @@ import {
   ScheduledItemsResult,
   ScheduledSurfaceItem,
 } from '../types';
-import { scheduledSurfaceAllowedValues } from '../../shared/utils';
+import {
+  getCorpusItemFromApprovedItem,
+  scheduledSurfaceAllowedValues,
+} from '../../shared/utils';
 import { groupBy } from '../../shared/utils';
 import { UserInputError } from 'apollo-server-errors';
 
@@ -120,24 +123,7 @@ export async function getItemsForScheduledSurface(
       scheduledDate: DateTime.fromJSDate(scheduledItem.scheduledDate).toFormat(
         'yyyy-MM-dd'
       ),
-      corpusItem: {
-        id: scheduledItem.approvedItem.externalId,
-        url: scheduledItem.approvedItem.url,
-        title: scheduledItem.approvedItem.title,
-        excerpt: scheduledItem.approvedItem.excerpt,
-        authors: scheduledItem.approvedItem.authors,
-        language: scheduledItem.approvedItem.language,
-        publisher: scheduledItem.approvedItem.publisher,
-        imageUrl: scheduledItem.approvedItem.imageUrl,
-        // so the type definition in /src/database/types has topic as optional,
-        // which typescript resolves as `string | undefined`. however, if the
-        // topic is missing in the db, prisma returns `null` - hence the
-        // nullish coalescing operator below.
-        //
-        // i wonder why typescript won't accept both. is there some deep dark
-        // JS reason? or is it just better practice?
-        topic: scheduledItem.approvedItem.topic ?? undefined,
-      },
+      corpusItem: getCorpusItemFromApprovedItem(scheduledItem.approvedItem),
     };
     return item;
   });

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -10,6 +10,7 @@ export const resolvers = {
     // The `items` subquery pulls in scheduled corpus items for a given date.
     items: getItemsForScheduledSurface,
   },
+  // The `CorpusItem` resolver resolves approved corpus items based on id.
   CorpusItem: {
     __resolveReference: getCorpusItem,
   },

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,7 +1,7 @@
 import { DateResolver } from 'graphql-scalars';
 import { getScheduledSurface } from './queries/ScheduledSurface';
 import { getItemsForScheduledSurface } from './queries/ScheduledSurfaceItem';
-import { getApprovedItemByExternalId } from '../../database/queries/ApprovedItem';
+import { getCorpusItem } from './queries/CorpusItem';
 
 export const resolvers = {
   // The Date resolver enforces the date to be in the YYYY-MM-DD format.
@@ -11,13 +11,7 @@ export const resolvers = {
     items: getItemsForScheduledSurface,
   },
   CorpusItem: {
-    __resolveReference: async (item, { db }) => {
-      const { id } = item;
-
-      /**
-       */
-      return getApprovedItemByExternalId(db, id);
-    },
+    __resolveReference: getCorpusItem,
   },
   Query: {
     // Gets the metadata for a Scheduled Surface (for example, New Tab).

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,6 +1,7 @@
 import { DateResolver } from 'graphql-scalars';
 import { getScheduledSurface } from './queries/ScheduledSurface';
 import { getItemsForScheduledSurface } from './queries/ScheduledSurfaceItem';
+import { getApprovedItemByExternalId } from '../../database/queries/ApprovedItem';
 
 export const resolvers = {
   // The Date resolver enforces the date to be in the YYYY-MM-DD format.
@@ -8,6 +9,15 @@ export const resolvers = {
   ScheduledSurface: {
     // The `items` subquery pulls in scheduled corpus items for a given date.
     items: getItemsForScheduledSurface,
+  },
+  CorpusItem: {
+    __resolveReference: async (item, { db }) => {
+      const { id } = item;
+
+      /**
+       */
+      return getApprovedItemByExternalId(db, id);
+    },
   },
   Query: {
     // Gets the metadata for a Scheduled Surface (for example, New Tab).

--- a/src/public/resolvers/queries/CorpusItem.integration.ts
+++ b/src/public/resolvers/queries/CorpusItem.integration.ts
@@ -1,10 +1,9 @@
 import { expect } from 'chai';
 import { getServer } from '../../../test/public-server';
 import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
-import {CORPUS_ITEM_REFERENCE_RESOLVER, GET_SCHEDULED_SURFACE} from './sample-queries.gql';
-import {createApprovedItemHelper} from "../../../test/helpers";
-import {db} from "../../../test/admin-server";
-import {APPROVED_ITEM_REFERENCE_RESOLVER} from "../../../admin/resolvers/queries/sample-queries.gql";
+import { CORPUS_ITEM_REFERENCE_RESOLVER } from './sample-queries.gql';
+import { createApprovedItemHelper } from '../../../test/helpers';
+import { db } from '../../../test/admin-server';
 
 describe('CorpusItem reference resolver', () => {
   const server = getServer(new CuratedCorpusEventEmitter());

--- a/src/public/resolvers/queries/CorpusItem.integration.ts
+++ b/src/public/resolvers/queries/CorpusItem.integration.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import { getServer } from '../../../test/public-server';
+import { CuratedCorpusEventEmitter } from '../../../events/curatedCorpusEventEmitter';
+import {CORPUS_ITEM_REFERENCE_RESOLVER, GET_SCHEDULED_SURFACE} from './sample-queries.gql';
+import {createApprovedItemHelper} from "../../../test/helpers";
+import {db} from "../../../test/admin-server";
+import {APPROVED_ITEM_REFERENCE_RESOLVER} from "../../../admin/resolvers/queries/sample-queries.gql";
+
+describe('queries: ScheduledSurface', () => {
+  const server = getServer(new CuratedCorpusEventEmitter());
+
+  beforeAll(async () => {
+    await server.start();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  describe('CorpusItem reference resolver', () => {
+    it('returns the approved item if it exists', async () => {
+      // Create a few items with known URLs.
+      const corpusItemInput = {
+        title: 'Story one',
+        url: 'https://www.sample-domain.com/what-zombies-can-teach-you-graphql',
+      };
+
+      const approvedItem = await createApprovedItemHelper(db, corpusItemInput);
+      const corpusItemId = approvedItem.externalId;
+
+      const result = await server.executeOperation({
+        query: CORPUS_ITEM_REFERENCE_RESOLVER,
+        variables: {
+          representations: [
+            {
+              __typename: 'CorpusItem',
+              id: corpusItemId,
+            },
+          ],
+        },
+      });
+
+      expect(result.errors).to.be.undefined;
+
+      expect(result.data).to.not.be.null;
+      expect(result.data?._entities).to.have.lengthOf(1);
+    });
+  });
+
+  it('should throw an error if the GUID provided is not known', async () => {
+    const result = await server.executeOperation({
+      query: GET_SCHEDULED_SURFACE,
+      variables: { id: 'ABRACADABRA' },
+    });
+
+    // There should be errors
+    expect(result.errors).not.to.be.null;
+
+    expect(result.errors?.[0].message).to.contain(
+      `Could not find Scheduled Surface with id of "ABRACADABRA"`
+    );
+    expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
+  });
+});

--- a/src/public/resolvers/queries/CorpusItem.ts
+++ b/src/public/resolvers/queries/CorpusItem.ts
@@ -1,0 +1,21 @@
+import { CorpusItem } from '../../../database/types';
+import { getApprovedItemByExternalId } from '../../../database/queries/ApprovedItem';
+import { getCorpusItemFromApprovedItem } from '../../../shared/utils';
+import { UserInputError } from 'apollo-server-errors';
+
+/**
+ * Pulls in scheduled items for a given date and surface (e.g., NEW_TAB_EN_US).
+ *
+ * @param item
+ * @param db
+ */
+export async function getCorpusItem(item, { db }): Promise<CorpusItem> {
+  const { id } = item;
+
+  const approvedItem = await getApprovedItemByExternalId(db, id);
+  if (!approvedItem) {
+    throw new UserInputError(`Could not find Corpus Item with id of "${id}".`);
+  }
+
+  return getCorpusItemFromApprovedItem(approvedItem);
+}

--- a/src/public/resolvers/queries/CorpusItem.ts
+++ b/src/public/resolvers/queries/CorpusItem.ts
@@ -4,7 +4,7 @@ import { getCorpusItemFromApprovedItem } from '../../../shared/utils';
 import { UserInputError } from 'apollo-server-errors';
 
 /**
- * Pulls in scheduled items for a given date and surface (e.g., NEW_TAB_EN_US).
+ * Pulls in approved corpus items for a given id.
  *
  * @param item
  * @param db

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -1,4 +1,5 @@
 import { gql } from 'apollo-server';
+import {CuratedItemData} from "../../../shared/fragments.gql";
 
 export const GET_SCHEDULED_SURFACE = gql`
   query scheduledSurface($id: ID!) {
@@ -31,6 +32,20 @@ export const GET_SCHEDULED_SURFACE_WITH_ITEMS = gql`
           publisher
           imageUrl
           topic
+        }
+      }
+    }
+  }
+`;
+
+export const CORPUS_ITEM_REFERENCE_RESOLVER = gql`
+  query ($representations: [_Any!]!) {
+    _entities(representations: $representations) {
+      ... on CorpusItem {
+        id
+        title
+        authors {
+          name
         }
       }
     }

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -1,5 +1,4 @@
 import { gql } from 'apollo-server';
-import {CuratedItemData} from "../../../shared/fragments.gql";
 
 export const GET_SCHEDULED_SURFACE = gql`
   query scheduledSurface($id: ID!) {

--- a/src/shared/utils.spec.ts
+++ b/src/shared/utils.spec.ts
@@ -1,9 +1,12 @@
-import { MozillaAccessGroup } from './types';
+import {CorpusItemSource, MozillaAccessGroup, Topics} from './types';
 import {
+  getCorpusItemFromApprovedItem,
   getScheduledSurfaceByAccessGroup,
   getScheduledSurfaceByGuid,
   toUtcDateString,
 } from './utils';
+import {ApprovedItem, ApprovedItemAuthor} from "../database/types";
+import {CuratedStatus} from "@prisma/client";
 
 describe('shared/utils', () => {
   describe('toUtcDateString', () => {
@@ -60,6 +63,46 @@ describe('shared/utils', () => {
 
     it('should return undefined for an invalid guid', () => {
       expect(getScheduledSurfaceByGuid('STONE_CUTTERS')).toBeUndefined();
+    });
+  });
+
+  describe('getCorpusItemFromApprovedItem', () => {
+    it('should map a ApprovedItem to a CorpusItem', () => {
+      const approvedItem: ApprovedItem = {
+        externalId: '123-abc',
+        prospectId: 'abc-123',
+        url: 'https://test.com',
+        status: CuratedStatus.CORPUS,
+        id: 123,
+        title: 'Test title',
+        excerpt: 'An excerpt',
+        language: 'EN',
+        publisher: 'The Times of Narnia',
+        imageUrl: 'https://test.com/image.png',
+        topic: Topics.EDUCATION,
+        source: CorpusItemSource.PROSPECT,
+        isCollection: false,
+        isTimeSensitive: false,
+        isSyndicated: false,
+        createdAt: new Date(),
+        createdBy: 'Anyone',
+        updatedAt: new Date(),
+        updatedBy: null,
+      };
+
+      const result = getCorpusItemFromApprovedItem(approvedItem);
+
+      expect(result).not.toBeUndefined();
+
+      expect(result.id).toEqual(approvedItem.externalId);
+      expect(result.url).toEqual(approvedItem.url);
+      expect(result.title).toEqual(approvedItem.title);
+      expect(result.excerpt).toEqual(approvedItem.excerpt);
+      expect(result.authors).toEqual(approvedItem.authors);
+      expect(result.language).toEqual(approvedItem.language);
+      expect(result.publisher).toEqual(approvedItem.publisher);
+      expect(result.imageUrl).toEqual(approvedItem.imageUrl);
+      expect(result.topic).toEqual(approvedItem.topic);
     });
   });
 });

--- a/src/shared/utils.spec.ts
+++ b/src/shared/utils.spec.ts
@@ -88,6 +88,7 @@ describe('shared/utils', () => {
         createdBy: 'Anyone',
         updatedAt: new Date(),
         updatedBy: null,
+        authors: [{ name: 'A.U. Thur', sortOrder: 0 }],
       };
 
       const result = getCorpusItemFromApprovedItem(approvedItem);

--- a/src/shared/utils.spec.ts
+++ b/src/shared/utils.spec.ts
@@ -67,7 +67,7 @@ describe('shared/utils', () => {
   });
 
   describe('getCorpusItemFromApprovedItem', () => {
-    it('should map a ApprovedItem to a CorpusItem', () => {
+    it('should map an ApprovedItem to a CorpusItem', () => {
       const approvedItem: ApprovedItem = {
         externalId: '123-abc',
         prospectId: 'abc-123',

--- a/src/shared/utils.spec.ts
+++ b/src/shared/utils.spec.ts
@@ -1,12 +1,12 @@
-import {CorpusItemSource, MozillaAccessGroup, Topics} from './types';
+import { CorpusItemSource, MozillaAccessGroup, Topics } from './types';
 import {
   getCorpusItemFromApprovedItem,
   getScheduledSurfaceByAccessGroup,
   getScheduledSurfaceByGuid,
   toUtcDateString,
 } from './utils';
-import {ApprovedItem, ApprovedItemAuthor} from "../database/types";
-import {CuratedStatus} from "@prisma/client";
+import { ApprovedItem } from '../database/types';
+import { CuratedStatus } from '@prisma/client';
 
 describe('shared/utils', () => {
   describe('toUtcDateString', () => {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,6 +1,9 @@
 import { ScheduledSurface, ScheduledSurfaces } from './types';
-import {ApprovedItem, ApprovedItemAuthor, CorpusItem, ScheduledSurfaceItem} from "../database/types";
-import {DateTime} from "luxon";
+import {
+  ApprovedItem,
+  ApprovedItemAuthor,
+  CorpusItem,
+} from '../database/types';
 
 /**
  * Generate an integer Epoch time from a JavaScript Date object.

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,4 +1,6 @@
 import { ScheduledSurface, ScheduledSurfaces } from './types';
+import {ApprovedItem, ApprovedItemAuthor, CorpusItem, ScheduledSurfaceItem} from "../database/types";
+import {DateTime} from "luxon";
 
 /**
  * Generate an integer Epoch time from a JavaScript Date object.
@@ -72,5 +74,28 @@ export const getScheduledSurfaceByGuid = (
   return ScheduledSurfaces.find(
     (surface: ScheduledSurface) => surface.guid === guid
   );
+};
+
+export const getCorpusItemFromApprovedItem = (
+  approvedItem: ApprovedItem
+): CorpusItem => {
+  return {
+    id: approvedItem.externalId,
+    url: approvedItem.url,
+    title: approvedItem.title,
+    excerpt: approvedItem.excerpt,
+    authors: approvedItem.authors as ApprovedItemAuthor[],
+    language: approvedItem.language,
+    publisher: approvedItem.publisher,
+    imageUrl: approvedItem.imageUrl,
+    // so the type definition in /src/database/types has topic as optional,
+    // which typescript resolves as `string | undefined`. however, if the
+    // topic is missing in the db, prisma returns `null` - hence the
+    // nullish coalescing operator below.
+    //
+    // i wonder why typescript won't accept both. is there some deep dark
+    // JS reason? or is it just better practice?
+    topic: approvedItem.topic ?? undefined,
+  };
 };
 // End Pocket shared data utility constructs/functions


### PR DESCRIPTION
## Goal
Allow us to resolve Corpus Items, which is needed for the [setupMomentSlate](https://studio.apollographql.com/graph/pocket-client-api/schema/reference?variant=current#setupMomentSlate). This query will be used as part of an experiment in a couple weeks to show new Web users stories during onboarding.

## I'd love feedback/perspectives on:
Is there a better place for converting ApprovedItem to CorpusItem than utils.ts?

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/HS-32

Documentation:
* [Spec PR #144](https://github.com/Pocket/spec/pull/144)

Apollo queries:
* [setupMomentSlate query with only an _id_ field](https://studio.apollographql.com/graph/pocket-client-api/explorer?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAMoIowAOAshIqiQDYCGKCRwAOkkUQM7kqteiiat2XHryJ4EUOvTCsAlhCR8O3adPl5KMPgEk2cTVO29lYLRYC%2BN3valPbIW0A&variant=current)
* [setupMomentSlate query that errors because a title is requested](https://studio.apollographql.com/graph/pocket-client-api/explorer?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAMoIowAOAshIqiQDYCGKCRwAOkkUQM7kqteiiat2XHryJ4EUOvTCsAlhCR8O3adPl5KMPgEk2cTVO29lYLRd4plKRghvaAvi6LupX1yFdA&variant=current)

Sentry error:
* https://sentry.io/organizations/pocket/issues/3319008876/?project=5938284&query=is%3Aunresolved
