### PR TITLE
chore(snowplow): add publisher to reviewed corpus item

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -69,7 +69,7 @@ export default {
     schemas: {
       objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-5',
       reviewedCorpusItem:
-        'iglu:com.pocket/reviewed_corpus_item/jsonschema/1-0-3',
+        'iglu:com.pocket/reviewed_corpus_item/jsonschema/1-0-4',
       scheduledCorpusItem:
         'iglu:com.pocket/scheduled_corpus_item/jsonschema/1-0-2',
     },

--- a/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
+++ b/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
@@ -94,6 +94,7 @@ function assertValidSnowplowApprovedItemEvents(eventContext) {
         url: approvedItem.url,
         title: approvedItem.title,
         excerpt: approvedItem.excerpt,
+        publisher: approvedItem.publisher,
         authors:
           approvedItem.authors?.map(
             (author: ApprovedItemAuthor) => author.name

--- a/src/events/snowplow/ReviewedItemSnowplowHandler.ts
+++ b/src/events/snowplow/ReviewedItemSnowplowHandler.ts
@@ -135,6 +135,7 @@ export class ReviewedItemSnowplowHandler extends CuratedCorpusSnowplowHandler {
       title: item.title,
       language: item.language,
       excerpt: item.excerpt,
+      publisher: item.publisher,
       // we only send author name to snowplow, not the sort order
       authors: item.authors.map((author: ApprovedItemAuthor) => author.name),
       image_url: item.imageUrl,

--- a/src/events/snowplow/schema.ts
+++ b/src/events/snowplow/schema.ts
@@ -30,6 +30,9 @@ export type CuratedCorpusItemUpdate = {
  * Entity to describe an item that has been reviewed for the Pocket
  * recommendation corpus. Expected (new and old) on all object_update
  * events where object = reviewed_corpus_item.
+ *
+ * Note that many of the properties below are optional because a reviewed
+ * corpus item may mean rejected, in which case many properties may be absent.
  */
 export type ReviewedCorpusItem = {
   /**
@@ -79,7 +82,10 @@ export type ReviewedCorpusItem = {
    * The excerpt for the reviewed corpus item.
    */
   excerpt?: string;
-
+  /**
+   * The publisher for the reviewed corpus item.
+   */
+  publisher?: string;
   /**
    * The list of authors for the reviewed corpus item.
    */


### PR DESCRIPTION
## Goal

send `publisher` to snowplow for reviewed corpus items.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1553