### PR TITLE
feat(query): [BACK-1558] Create a query to get a curated item by its `externalId`

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -863,6 +863,16 @@ type Query {
     ): ApprovedCorpusItem
 
     """
+    Retrieves an approved item with the given external ID.
+    """
+    approvedCorpusItem(
+        """
+        ID of the approved item. A string in UUID format.
+        """
+        externalId: ID!
+    ): ApprovedCorpusItem
+
+    """
     Retrieves all ScheduledSurfaces available to the given SSO user. Requires an Authorization header.
     """
     getScheduledSurfacesForUser: [ScheduledSurface!]!

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -865,7 +865,7 @@ type Query {
     """
     Retrieves an approved item with the given external ID.
     """
-    approvedCorpusItem(
+    approvedCorpusItemByExternalId(
         """
         ID of the approved item. A string in UUID format.
         """

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -85,7 +85,7 @@ export const resolvers = {
   },
   // The queries available
   Query: {
-    approvedCorpusItem: getApprovedItemByExternalId,
+    approvedCorpusItemByExternalId: getApprovedItemByExternalId,
     getApprovedCorpusItems: getApprovedItems,
     getRejectedCorpusItems: getRejectedItems,
     getScheduledCorpusItems: getScheduledItems,

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -2,6 +2,7 @@ import { DateResolver, NonNegativeIntResolver } from 'graphql-scalars';
 import { UnixTimestampResolver } from './fields/UnixTimestamp';
 import {
   getApprovedItems,
+  getApprovedItemByExternalId,
   getApprovedItemByUrl,
   getScheduledSurfaceHistory,
 } from './queries/ApprovedItem';
@@ -84,6 +85,7 @@ export const resolvers = {
   },
   // The queries available
   Query: {
+    approvedCorpusItem: getApprovedItemByExternalId,
     getApprovedCorpusItems: getApprovedItems,
     getRejectedCorpusItems: getRejectedItems,
     getScheduledCorpusItems: getScheduledItems,

--- a/src/admin/resolvers/queries/ApprovedItem.auth.integration.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.auth.integration.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { CuratedStatus } from '@prisma/client';
+import { ApprovedItem, CuratedStatus } from '@prisma/client';
 import { ACCESS_DENIED_ERROR, MozillaAccessGroup } from '../../../shared/types';
 import { db } from '../../../test/admin-server';
 import {
@@ -10,9 +10,14 @@ import {
 import {
   GET_APPROVED_ITEMS,
   GET_APPROVED_ITEM_BY_URL,
+  GET_APPROVED_ITEM_BY_EXTERNAL_ID,
 } from './sample-queries.gql';
 
-describe('queries: ApprovedCorpusItem - authentication', () => {
+describe('queries: approvedCorpusItem - authentication', () => {
+  // Save the sample items in a variable so that we can access their
+  // auto-generated props such as `externalId` in tests
+  const items: ApprovedItem[] = [];
+
   beforeAll(async () => {
     // clear out db to start fresh
     await clearDb(db);
@@ -42,7 +47,8 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
 
     // insert test stories into the db
     for (const story of stories) {
-      await createApprovedItemHelper(db, story);
+      const item = await createApprovedItemHelper(db, story);
+      items.push(item);
     }
   });
 
@@ -229,6 +235,100 @@ describe('queries: ApprovedCorpusItem - authentication', () => {
       expect(result.data?.getApprovedCorpusItemByUrl).to.be.null;
 
       expect(result.errors).not.to.be.undefined;
+      // check if the error we get is access denied error
+      expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
+    });
+  });
+
+  describe('approvedCorpusItem query', () => {
+    it('should get item when user has read-only access', async () => {
+      // Set up auth headers with read-only access
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.READONLY}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const result = await server.executeOperation({
+        query: GET_APPROVED_ITEM_BY_EXTERNAL_ID,
+        variables: {
+          externalId: items[0].externalId,
+        },
+      });
+
+      expect(result.data).not.to.be.null;
+      expect(result.errors).to.be.undefined;
+    });
+
+    it('should get item when user has only one scheduled surface access', async () => {
+      // Set up auth headers with access to a single Scheduled Surface
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.NEW_TAB_CURATOR_ENUS}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const result = await server.executeOperation({
+        query: GET_APPROVED_ITEM_BY_EXTERNAL_ID,
+        variables: {
+          externalId: items[1].externalId,
+        },
+      });
+
+      expect(result.data).not.to.be.null;
+      expect(result.errors).to.be.undefined;
+    });
+
+    it('should throw an error when user does not have the required access', async () => {
+      // Set up auth headers with no valid access group
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const result = await server.executeOperation({
+        query: GET_APPROVED_ITEM_BY_EXTERNAL_ID,
+        variables: {
+          externalId: items[2].externalId,
+        },
+      });
+
+      expect(result.data?.approvedCorpusItem).to.be.null;
+      expect(result.errors).not.to.be.undefined;
+
+      // check if the error we get is access denied error
+      expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');
+    });
+
+    it('should throw an error when request header groups are undefined', async () => {
+      // Set up auth headers with no valid access group
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: undefined,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const result = await server.executeOperation({
+        query: GET_APPROVED_ITEM_BY_EXTERNAL_ID,
+        variables: {
+          externalId: items[0].externalId,
+        },
+      });
+
+      expect(result.data?.approvedCorpusItem).to.be.null;
+      expect(result.errors).not.to.be.undefined;
+
       // check if the error we get is access denied error
       expect(result.errors?.[0].message).to.equal(ACCESS_DENIED_ERROR);
       expect(result.errors?.[0].extensions?.code).to.equal('UNAUTHENTICATED');

--- a/src/admin/resolvers/queries/ApprovedItem.auth.integration.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.auth.integration.ts
@@ -301,7 +301,7 @@ describe('queries: approvedCorpusItem - authentication', () => {
         },
       });
 
-      expect(result.data?.approvedCorpusItem).to.be.null;
+      expect(result.data?.approvedCorpusItemByExternalId).to.be.null;
       expect(result.errors).not.to.be.undefined;
 
       // check if the error we get is access denied error
@@ -326,7 +326,7 @@ describe('queries: approvedCorpusItem - authentication', () => {
         },
       });
 
-      expect(result.data?.approvedCorpusItem).to.be.null;
+      expect(result.data?.approvedCorpusItemByExternalId).to.be.null;
       expect(result.errors).not.to.be.undefined;
 
       // check if the error we get is access denied error

--- a/src/admin/resolvers/queries/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.integration.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../test/helpers';
 import {
   APPROVED_ITEM_REFERENCE_RESOLVER,
+  GET_APPROVED_ITEM_BY_EXTERNAL_ID,
   GET_APPROVED_ITEM_BY_URL,
   GET_APPROVED_ITEM_WITH_SCHEDULING_HISTORY,
   GET_APPROVED_ITEMS,
@@ -362,7 +363,6 @@ describe('queries: ApprovedCorpusItem', () => {
 
       // Does the query return all the properties of an Approved Item?
       expect(item.externalId).to.be.not.undefined;
-      expect(item.externalId).to.be.not.undefined;
       expect(item.prospectId).to.be.not.undefined;
       expect(item.title).to.be.not.undefined;
       expect(item.language).to.be.not.undefined;
@@ -391,6 +391,81 @@ describe('queries: ApprovedCorpusItem', () => {
 
       // There should be no data returned
       expect(result.data?.getApprovedCorpusItemByUrl).to.be.null;
+
+      // There should be no errors
+      expect(result.errors).to.be.undefined;
+    });
+  });
+
+  describe('approvedCorpusItem query', () => {
+    const items: ApprovedItem[] = [];
+
+    beforeAll(async () => {
+      // Create a few corpus items
+      const storyInput = [
+        {
+          title: 'Story one',
+        },
+        {
+          title: 'Story two',
+        },
+        {
+          title: 'Story three',
+        },
+      ];
+
+      for (const input of storyInput) {
+        const item = await createApprovedItemHelper(db, input);
+        items.push(item);
+      }
+    });
+
+    it('should get an existing approved item by externalId', async () => {
+      // Let's use a known external ID from the sample subset above
+      const result = await server.executeOperation({
+        query: GET_APPROVED_ITEM_BY_EXTERNAL_ID,
+        variables: {
+          externalId: items[0].externalId,
+        },
+      });
+
+      // There should be no errors
+      expect(result.errors).to.be.undefined;
+
+      // Proceed with verifying the data
+      // Is this really the item we wanted to retrieve?
+      const item = result.data?.approvedCorpusItem;
+      expect(item.externalId).to.equal(items[0].externalId);
+      expect(item.url).to.equal(items[0].url);
+
+      // Does the query return all the other properties of an Approved Item?
+      expect(item.externalId).to.be.not.undefined;
+      expect(item.prospectId).to.be.not.undefined;
+      expect(item.title).to.be.not.undefined;
+      expect(item.language).to.be.not.undefined;
+      expect(item.publisher).to.be.not.undefined;
+      expect(item.imageUrl).to.be.not.undefined;
+      expect(item.excerpt).to.be.not.undefined;
+      expect(item.status).to.be.not.undefined;
+      expect(item.topic).to.be.not.undefined;
+      expect(item.source).to.be.not.undefined;
+      expect(item.isCollection).to.be.a('boolean');
+      expect(item.isTimeSensitive).to.be.a('boolean');
+      expect(item.isSyndicated).to.be.a('boolean');
+    });
+
+    it('should return null when nothing for a given externalId is found', async () => {
+      const result = await server.executeOperation({
+        query: GET_APPROVED_ITEM_BY_EXTERNAL_ID,
+        variables: {
+          externalId: 'this-id-does-not-exist',
+        },
+      });
+
+      expect(result.data).to.have.property('approvedCorpusItem');
+
+      // There should be no data returned
+      expect(result.data?.approvedCorpusItem).to.be.null;
 
       // There should be no errors
       expect(result.errors).to.be.undefined;

--- a/src/admin/resolvers/queries/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.integration.ts
@@ -397,7 +397,7 @@ describe('queries: ApprovedCorpusItem', () => {
     });
   });
 
-  describe('approvedCorpusItem query', () => {
+  describe('approvedCorpusItemByExternalId query', () => {
     const items: ApprovedItem[] = [];
 
     beforeAll(async () => {
@@ -434,7 +434,7 @@ describe('queries: ApprovedCorpusItem', () => {
 
       // Proceed with verifying the data
       // Is this really the item we wanted to retrieve?
-      const item = result.data?.approvedCorpusItem;
+      const item = result.data?.approvedCorpusItemByExternalId;
       expect(item.externalId).to.equal(items[0].externalId);
       expect(item.url).to.equal(items[0].url);
 
@@ -462,10 +462,10 @@ describe('queries: ApprovedCorpusItem', () => {
         },
       });
 
-      expect(result.data).to.have.property('approvedCorpusItem');
+      expect(result.data).to.have.property('approvedCorpusItemByExternalId');
 
       // There should be no data returned
-      expect(result.data?.approvedCorpusItem).to.be.null;
+      expect(result.data?.approvedCorpusItemByExternalId).to.be.null;
 
       // There should be no errors
       expect(result.errors).to.be.undefined;

--- a/src/admin/resolvers/queries/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.integration.ts
@@ -559,7 +559,7 @@ describe('queries: ApprovedCorpusItem', () => {
       expect(result.errors).to.be.undefined;
 
       // There should be no data returned for the subquery (an empty array),
-      // since the this story doesn't have any entries on the UK New Tab
+      // since this story doesn't have any entries on the UK New Tab
       expect(
         result.data?.getApprovedCorpusItemByUrl.scheduledSurfaceHistory
       ).to.have.lengthOf(0);

--- a/src/admin/resolvers/queries/ApprovedItem.ts
+++ b/src/admin/resolvers/queries/ApprovedItem.ts
@@ -4,6 +4,7 @@ import config from '../../../config';
 import {
   getApprovedItems as dbGetApprovedItems,
   getApprovedItemByUrl as dbGetApprovedItemByUrl,
+  getApprovedItemByExternalId as dbGetApprovedItemByExternalId,
   getScheduledSurfaceHistory as dbGetScheduledSurfaceHistory,
 } from '../../../database/queries';
 import { ACCESS_DENIED_ERROR, ScheduledSurfaces } from '../../../shared/types';
@@ -79,6 +80,31 @@ export async function getApprovedItemByUrl(
   }
 
   return await dbGetApprovedItemByUrl(context.db, args.url);
+}
+
+/**
+ * This query returns an approved item with a given external ID if it finds one
+ * in the Curated Corpus (among approved items only), or return null
+ * if the external ID is not found
+ *
+ * @param parent
+ * @param args
+ * @param context
+ */
+export async function getApprovedItemByExternalId(
+  parent,
+  args,
+  context: IContext
+): Promise<ApprovedItem | null> {
+  //check if the user does not have the permissions to access this query
+  if (
+    !context.authenticatedUser.hasReadOnly &&
+    !context.authenticatedUser.canWriteToCorpus()
+  ) {
+    throw new AuthenticationError(ACCESS_DENIED_ERROR);
+  }
+
+  return await dbGetApprovedItemByExternalId(context.db, args.externalId);
 }
 
 /**

--- a/src/admin/resolvers/queries/sample-queries.gql.ts
+++ b/src/admin/resolvers/queries/sample-queries.gql.ts
@@ -81,6 +81,15 @@ export const GET_APPROVED_ITEM_BY_URL = gql`
   ${CuratedItemData}
 `;
 
+export const GET_APPROVED_ITEM_BY_EXTERNAL_ID = gql`
+  query approvedCorpusItem($externalId: ID!) {
+    approvedCorpusItem(externalId: $externalId) {
+      ...CuratedItemData
+    }
+  }
+  ${CuratedItemData}
+`;
+
 export const GET_APPROVED_ITEM_WITH_SCHEDULING_HISTORY = gql`
   query getApprovedCorpusItemByUrl(
     $url: String!

--- a/src/admin/resolvers/queries/sample-queries.gql.ts
+++ b/src/admin/resolvers/queries/sample-queries.gql.ts
@@ -82,8 +82,8 @@ export const GET_APPROVED_ITEM_BY_URL = gql`
 `;
 
 export const GET_APPROVED_ITEM_BY_EXTERNAL_ID = gql`
-  query approvedCorpusItem($externalId: ID!) {
-    approvedCorpusItem(externalId: $externalId) {
+  query approvedCorpusItemByExternalId($externalId: ID!) {
+    approvedCorpusItemByExternalId(externalId: $externalId) {
       ...CuratedItemData
     }
   }

--- a/src/database/queries/index.ts
+++ b/src/database/queries/index.ts
@@ -1,6 +1,7 @@
 export {
   getApprovedItems,
   getApprovedItemByUrl,
+  getApprovedItemByExternalId,
   getScheduledSurfaceHistory,
 } from './ApprovedItem';
 export {

--- a/src/public/resolvers/queries/CorpusItem.integration.ts
+++ b/src/public/resolvers/queries/CorpusItem.integration.ts
@@ -61,7 +61,7 @@ describe('CorpusItem reference resolver', () => {
     expect(result.errors).not.to.be.null;
 
     expect(result.errors?.[0].message).to.contain(
-      `Could not find Corpus Item with id of "ABRACADABRA"`
+      `Could not find Corpus Item with ID of "ABRACADABRA"`
     );
     expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
   });

--- a/src/public/resolvers/queries/CorpusItem.ts
+++ b/src/public/resolvers/queries/CorpusItem.ts
@@ -14,7 +14,7 @@ export async function getCorpusItem(item, { db }): Promise<CorpusItem> {
 
   const approvedItem = await getApprovedItemByExternalId(db, id);
   if (!approvedItem) {
-    throw new UserInputError(`Could not find Corpus Item with id of "${id}".`);
+    throw new UserInputError(`Could not find Corpus Item with ID of "${id}".`);
   }
 
   return getCorpusItemFromApprovedItem(approvedItem);


### PR DESCRIPTION
## Goal

Add a new query to unblock creating individual pages for curated items on the frontend.

- Added a new query to schema with a filter on `externalId`.

- Added integration tests.


## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1558