### PR TITLE
feat(rejected items): [BACK-1492] Make fields optional on rejected items

### DIFF
--- a/prisma/migrations/20220829024459_rename_rejected_items_and_make_topic_optional/migration.sql
+++ b/prisma/migrations/20220829024459_rename_rejected_items_and_make_topic_optional/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to drop the `RejectedCuratedCorpusItem` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE `RejectedCuratedCorpusItem`;
+
+-- CreateTable
+CREATE TABLE `RejectedItem` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `externalId` VARCHAR(255) NOT NULL,
+    `prospectId` VARCHAR(255) NULL,
+    `url` VARCHAR(500) NOT NULL,
+    `title` VARCHAR(255) NULL,
+    `topic` VARCHAR(255) NULL,
+    `language` VARCHAR(2) NULL,
+    `publisher` VARCHAR(255) NULL,
+    `reason` VARCHAR(255) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `createdBy` VARCHAR(255) NOT NULL,
+
+    UNIQUE INDEX `RejectedItem_externalId_key`(`externalId`),
+    UNIQUE INDEX `RejectedItem_url_key`(`url`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,14 +63,14 @@ model ApprovedItem {
   @@unique([url])
 }
 
-model RejectedCuratedCorpusItem {
+model RejectedItem {
   // fields
   id         Int      @id @default(autoincrement())
   externalId String   @default(uuid()) @db.VarChar(255)
   prospectId String?  @db.VarChar(255)
   url        String   @db.VarChar(500)
   title      String?  @db.VarChar(255)
-  topic      String   @db.VarChar(255)
+  topic      String?   @db.VarChar(255)
   language   String?  @db.VarChar(2)
   publisher  String?  @db.VarChar(255)
   // Can be multiple reasons. For the MVP, Snowplow and the frontend

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,8 +1,8 @@
 import { PrismaClient } from '@prisma/client';
 import {
   createApprovedItemHelper,
+  createRejectedItemHelper,
   createScheduledItemHelper,
-  createRejectedCuratedCorpusItemHelper,
 } from '../src/test/helpers';
 import { faker } from '@faker-js/faker';
 
@@ -42,7 +42,7 @@ async function main() {
   ];
 
   for (const title of rejectedItemTitles) {
-    await createRejectedCuratedCorpusItemHelper(prisma, { title });
+    await createRejectedItemHelper(prisma, { title });
   }
 }
 

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -231,20 +231,20 @@ type RejectedCorpusItem @key(fields: "url") {
     """
     The title of the story.
     """
-    title: String!
+    title: String
     """
     A topic this story best fits in.
     Temporarily a string value that will be provided by Prospect API, possibly an enum in the future.
     """
-    topic: String!
+    topic: String
     """
     What language this story is in. This is a two-letter code, for example, 'EN' for English.
     """
-    language: CorpusLanguage!
+    language: CorpusLanguage
     """
     The name of the online publication that published this story.
     """
-    publisher: String!
+    publisher: String
     """
     Reason why it was rejected. Can be multiple reasons. Will likely be stored either as comma-separated values or JSON.
     """

--- a/src/admin/context.ts
+++ b/src/admin/context.ts
@@ -1,6 +1,6 @@
 import { S3 } from 'aws-sdk';
 import { IncomingHttpHeaders } from 'http';
-import { PrismaClient, RejectedCuratedCorpusItem } from '@prisma/client';
+import { PrismaClient, RejectedItem } from '@prisma/client';
 import { client } from '../database/client';
 import { ApprovedItem, ScheduledItem } from '../database/types';
 import { CuratedCorpusEventEmitter } from '../events/curatedCorpusEventEmitter';
@@ -41,7 +41,7 @@ export interface IContext {
 
   emitReviewedCorpusItemEvent(
     event: ReviewedCorpusItemEventType,
-    reviewedCorpusItem: ApprovedItem | RejectedCuratedCorpusItem
+    reviewedCorpusItem: ApprovedItem | RejectedItem
   ): void;
 
   emitScheduledCorpusItemEvent(
@@ -136,7 +136,7 @@ export class ContextManager implements IContext {
 
   emitReviewedCorpusItemEvent(
     event: ReviewedCorpusItemEventType,
-    reviewedCorpusItem: ApprovedItem | RejectedCuratedCorpusItem
+    reviewedCorpusItem: ApprovedItem | RejectedItem
   ): void {
     this.eventEmitter.emitEvent<ReviewedCorpusItemPayload>(event, {
       reviewedCorpusItem,

--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -6,7 +6,7 @@ import { db } from '../../../test/admin-server';
 import {
   clearDb,
   createApprovedItemHelper,
-  createRejectedCuratedCorpusItemHelper,
+  createRejectedItemHelper,
   createScheduledItemHelper,
   getServerWithMockedHeaders,
 } from '../../../test/helpers';
@@ -202,7 +202,7 @@ describe('mutations: ApprovedItem', () => {
       eventEmitter.on(ReviewedCorpusItemEventType.ADD_ITEM, eventTracker);
 
       // Create an approved item with a set URL
-      await createRejectedCuratedCorpusItemHelper(db, {
+      await createRejectedItemHelper(db, {
         title: 'I was here first!',
         url: 'https://test.com/docker',
       });

--- a/src/admin/resolvers/mutations/RejectedItem.integration.ts
+++ b/src/admin/resolvers/mutations/RejectedItem.integration.ts
@@ -4,7 +4,7 @@ import { db } from '../../../test/admin-server';
 import {
   clearDb,
   createApprovedItemHelper,
-  createRejectedCuratedCorpusItemHelper,
+  createRejectedItemHelper,
   getServerWithMockedHeaders,
 } from '../../../test/helpers';
 import { CREATE_REJECTED_ITEM } from './sample-mutations.gql';
@@ -155,7 +155,7 @@ describe('mutations: RejectedItem', () => {
       eventEmitter.on(ReviewedCorpusItemEventType.REJECT_ITEM, eventTracker);
 
       // Create a rejected item with a set URL
-      await createRejectedCuratedCorpusItemHelper(db, {
+      await createRejectedItemHelper(db, {
         title: 'I was here first!',
         url: 'https://test.com/docker',
       });

--- a/src/admin/resolvers/mutations/RejectedItem.ts
+++ b/src/admin/resolvers/mutations/RejectedItem.ts
@@ -1,5 +1,5 @@
 import { AuthenticationError, UserInputError } from 'apollo-server-errors';
-import { RejectedCuratedCorpusItem } from '@prisma/client';
+import { RejectedItem } from '@prisma/client';
 import { createRejectedItem as dbCreateRejectedItem } from '../../../database/mutations';
 import { ReviewedCorpusItemEventType } from '../../../events/types';
 import { RejectionReason, ACCESS_DENIED_ERROR } from '../../../shared/types';
@@ -17,7 +17,7 @@ export async function createRejectedItem(
   parent,
   { data },
   context: IContext
-): Promise<RejectedCuratedCorpusItem> {
+): Promise<RejectedItem> {
   // check if user is not authorized to reject an item
   if (!context.authenticatedUser.canWriteToCorpus()) {
     throw new AuthenticationError(ACCESS_DENIED_ERROR);

--- a/src/admin/resolvers/queries/RejectedItem.auth.integration.ts
+++ b/src/admin/resolvers/queries/RejectedItem.auth.integration.ts
@@ -1,7 +1,7 @@
 import { db } from '../../../test/admin-server';
 import {
   clearDb,
-  createRejectedCuratedCorpusItemHelper,
+  createRejectedItemHelper,
   getServerWithMockedHeaders,
 } from '../../../test/helpers';
 import { ACCESS_DENIED_ERROR, MozillaAccessGroup } from '../../../shared/types';
@@ -40,7 +40,7 @@ describe('queries: RejectedCorpusItem (authentication)', () => {
     await clearDb(db);
 
     for (const item of rejectedCorpusItems) {
-      await createRejectedCuratedCorpusItemHelper(db, item);
+      await createRejectedItemHelper(db, item);
     }
   });
 

--- a/src/admin/resolvers/queries/RejectedItem.integration.ts
+++ b/src/admin/resolvers/queries/RejectedItem.integration.ts
@@ -1,10 +1,7 @@
 import { expect } from 'chai';
-import { RejectedCuratedCorpusItem as dbRejectedCuratedCorpusItem } from '@prisma/client';
+import { RejectedItem as dbRejectedItem } from '@prisma/client';
 import { db } from '../../../test/admin-server';
-import {
-  clearDb,
-  createRejectedCuratedCorpusItemHelper,
-} from '../../../test/helpers';
+import { clearDb, createRejectedItemHelper } from '../../../test/helpers';
 import {
   GET_REJECTED_ITEMS,
   REJECTED_ITEM_REFERENCE_RESOLVER,
@@ -37,7 +34,7 @@ describe('queries: RejectedCorpusItem', () => {
 
   describe('getRejectedCorpusItem query', () => {
     // Fake sample Rejected Curated Corpus items
-    const rejectedCuratedCorpusItems = [
+    const rejectedItems = [
       {
         title: '10 Unforgivable Sins Of PHP',
         language: 'EN',
@@ -85,8 +82,8 @@ describe('queries: RejectedCorpusItem', () => {
     ];
 
     beforeAll(async () => {
-      for (const item of rejectedCuratedCorpusItems) {
-        await createRejectedCuratedCorpusItemHelper(db, item);
+      for (const item of rejectedItems) {
+        await createRejectedItemHelper(db, item);
       }
     });
 
@@ -99,10 +96,10 @@ describe('queries: RejectedCorpusItem', () => {
       });
 
       expect(data?.getRejectedCorpusItems.edges).to.have.length(
-        rejectedCuratedCorpusItems.length
+        rejectedItems.length
       );
       expect(data?.getRejectedCorpusItems.totalCount).to.equal(
-        rejectedCuratedCorpusItems.length
+        rejectedItems.length
       );
     });
 
@@ -125,7 +122,7 @@ describe('queries: RejectedCorpusItem', () => {
         },
       });
 
-      const firstItem: dbRejectedCuratedCorpusItem =
+      const firstItem: dbRejectedItem =
         data?.getRejectedCorpusItems.edges[0].node;
       // The important thing to test here is that the query returns all of these
       // properties without falling over, and not that they hold any specific value.
@@ -219,7 +216,7 @@ describe('queries: RejectedCorpusItem', () => {
         },
       });
 
-      const germanItems = rejectedCuratedCorpusItems.filter(
+      const germanItems = rejectedItems.filter(
         (item) => item.language === 'DE'
       );
       // we only have three stories in German set up before each test
@@ -344,7 +341,7 @@ describe('queries: RejectedCorpusItem', () => {
       ];
 
       for (const input of storyInput) {
-        await createRejectedCuratedCorpusItemHelper(db, input);
+        await createRejectedItemHelper(db, input);
       }
     });
 

--- a/src/admin/resolvers/queries/RejectedItem.ts
+++ b/src/admin/resolvers/queries/RejectedItem.ts
@@ -1,9 +1,9 @@
 import { Connection } from '@devoxa/prisma-relay-cursor-connection';
-import { RejectedCuratedCorpusItem } from '@prisma/client';
+import { RejectedItem } from '@prisma/client';
 import config from '../../../config';
 import {
   getRejectedItemByUrl as dbGetRejectedItemByUrl,
-  getRejectedCuratedCorpusItems as dbGetRejectedCuratedCorpusItems,
+  getRejectedItems as dbGetRejectedItems,
 } from '../../../database/queries';
 import { IContext } from '../../context';
 import { AuthenticationError } from 'apollo-server-errors';
@@ -20,7 +20,7 @@ export async function getRejectedItems(
   parent,
   args,
   context: IContext
-): Promise<Connection<RejectedCuratedCorpusItem>> {
+): Promise<Connection<RejectedItem>> {
   //check if the user has the required permissions to access this query
   if (
     !context.authenticatedUser.hasReadOnly &&
@@ -51,11 +51,7 @@ export async function getRejectedItems(
     }
   }
 
-  return await dbGetRejectedCuratedCorpusItems(
-    context.db,
-    pagination,
-    args.filters
-  );
+  return await dbGetRejectedItems(context.db, pagination, args.filters);
 }
 
 /**
@@ -71,7 +67,7 @@ export async function getRejectedItemByUrl(
   parent,
   args,
   context: IContext
-): Promise<RejectedCuratedCorpusItem | null> {
+): Promise<RejectedItem | null> {
   //check if the user does not have the permissions to access this query
   if (
     !context.authenticatedUser.hasReadOnly &&

--- a/src/database/helpers/checkCorpusUrl.ts
+++ b/src/database/helpers/checkCorpusUrl.ts
@@ -25,7 +25,7 @@ export const checkCorpusUrl = async (
   // Do another check to make sure it hasn't already been added by another user
   // to the Rejected Corpus - an edge case the frontend should never allow but
   // that we should cater for nevertheless.
-  const rejectedUrlExists = await db.rejectedCuratedCorpusItem.count({
+  const rejectedUrlExists = await db.rejectedItem.count({
     where: { url },
   });
 

--- a/src/database/mutations/RejectedItem.ts
+++ b/src/database/mutations/RejectedItem.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, RejectedCuratedCorpusItem } from '@prisma/client';
+import { PrismaClient, RejectedItem } from '@prisma/client';
 import { CreateRejectedItemInput } from '../types';
 import { checkCorpusUrl } from '../helpers/checkCorpusUrl';
 
@@ -13,11 +13,11 @@ export async function createRejectedItem(
   db: PrismaClient,
   data: CreateRejectedItemInput,
   username: string
-): Promise<RejectedCuratedCorpusItem> {
+): Promise<RejectedItem> {
   // Check if an item with this URL has already been created in the Curated Corpus.
   await checkCorpusUrl(db, data.url);
 
-  return db.rejectedCuratedCorpusItem.create({
+  return db.rejectedItem.create({
     data: {
       ...data,
       // Use the SSO username here.

--- a/src/database/queries/RejectedItem.ts
+++ b/src/database/queries/RejectedItem.ts
@@ -1,17 +1,17 @@
-import { RejectedCuratedCorpusItem, PrismaClient } from '@prisma/client';
+import { RejectedItem, PrismaClient } from '@prisma/client';
 // need this to be able to use Prisma-native types for orderBy and filter clauses
 import { Prisma } from '@prisma/client';
 import {
   findManyCursorConnection,
   Connection,
 } from '@devoxa/prisma-relay-cursor-connection';
-import { RejectedCuratedCorpusItemFilter, PaginationInput } from '../types';
+import { RejectedItemFilter, PaginationInput } from '../types';
 
 /**
- * A dedicated type for the unique cursor value used in the getRejectedCuratedCorpusItems query.
+ * A dedicated type for the unique cursor value used in the getRejectedCorpusItems query.
  * Essential to get findManyCursorConnection to work as expected.
  */
-type RejectedCuratedCorpusItemCursor = {
+type RejectedItemCursor = {
   externalId: string;
 };
 
@@ -22,14 +22,14 @@ type RejectedCuratedCorpusItemCursor = {
  * @param pagination
  * @param filters
  */
-export async function getRejectedCuratedCorpusItems(
+export async function getRejectedItems(
   db: PrismaClient,
   pagination: PaginationInput,
-  filters: RejectedCuratedCorpusItemFilter
-): Promise<Connection<RejectedCuratedCorpusItem>> {
+  filters: RejectedItemFilter
+): Promise<Connection<RejectedItem>> {
   // Set up the SQL clauses with our defaults (orderBy) and any filters supplied
   // by the client.
-  const baseArgs: Prisma.RejectedCuratedCorpusItemFindManyArgs = {
+  const baseArgs: Prisma.RejectedItemFindManyArgs = {
     orderBy: { createdAt: 'desc' },
     where: constructWhereClauseFromFilters(filters),
   };
@@ -40,13 +40,9 @@ export async function getRejectedCuratedCorpusItems(
    * The Relay-style pagination implemented for this query is the same as the getApprovedItems query.
    * Detailed comments explaining the callback function below are in ApprovedItem.ts
    */
-
-  return findManyCursorConnection<
-    RejectedCuratedCorpusItem,
-    RejectedCuratedCorpusItemCursor
-  >(
-    (args) => db.rejectedCuratedCorpusItem.findMany({ ...args, ...baseArgs }),
-    () => db.rejectedCuratedCorpusItem.count({ where: baseArgs.where }),
+  return findManyCursorConnection<RejectedItem, RejectedItemCursor>(
+    (args) => db.rejectedItem.findMany({ ...args, ...baseArgs }),
+    () => db.rejectedItem.count({ where: baseArgs.where }),
     pagination,
     {
       getCursor: (record) => ({
@@ -67,8 +63,8 @@ export async function getRejectedCuratedCorpusItems(
  * @param filters
  */
 const constructWhereClauseFromFilters = (
-  filters: RejectedCuratedCorpusItemFilter
-): Prisma.RejectedCuratedCorpusItemWhereInput => {
+  filters: RejectedItemFilter
+): Prisma.RejectedItemWhereInput => {
   // Early exit if no filters are provided
   if (!filters) return {};
 
@@ -93,6 +89,6 @@ const constructWhereClauseFromFilters = (
 export async function getRejectedItemByUrl(
   db: PrismaClient,
   url: string
-): Promise<RejectedCuratedCorpusItem | null> {
-  return db.rejectedCuratedCorpusItem.findUnique({ where: { url } });
+): Promise<RejectedItem | null> {
+  return db.rejectedItem.findUnique({ where: { url } });
 }

--- a/src/database/queries/index.ts
+++ b/src/database/queries/index.ts
@@ -4,10 +4,7 @@ export {
   getApprovedItemByExternalId,
   getScheduledSurfaceHistory,
 } from './ApprovedItem';
-export {
-  getRejectedCuratedCorpusItems,
-  getRejectedItemByUrl,
-} from './RejectedCuratedCorpusItem';
+export { getRejectedItems, getRejectedItemByUrl } from './RejectedItem';
 export {
   getScheduledItems,
   getItemsForScheduledSurface,

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -48,7 +48,7 @@ export type ApprovedItemFilter = {
   url?: string;
 };
 
-export type RejectedCuratedCorpusItemFilter = {
+export type RejectedItemFilter = {
   url?: string;
   title?: string;
   topic?: string;

--- a/src/events/curatedCorpusEventEmitter.spec.ts
+++ b/src/events/curatedCorpusEventEmitter.spec.ts
@@ -9,7 +9,7 @@ import config from '../config';
 import sinon from 'sinon';
 import { getUnixTimestamp } from '../shared/utils';
 import { ApprovedItem } from '../database/types';
-import { CuratedStatus, RejectedCuratedCorpusItem } from '@prisma/client';
+import { CuratedStatus, RejectedItem } from '@prisma/client';
 import { CorpusItemSource, Topics } from '../shared/types';
 
 describe('CuratedCorpusEventEmitter', () => {
@@ -140,7 +140,7 @@ describe('CuratedCorpusEventEmitter', () => {
 
   it('should emit a REJECT_ITEM event with expected data', () => {
     // This event returns the data stored in RejectedItem entity internally
-    const rejectedItem: RejectedCuratedCorpusItem = {
+    const rejectedItem: RejectedItem = {
       id: 123,
       externalId: '345-abc',
       prospectId: 'abc-543',

--- a/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
+++ b/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { CuratedStatus, RejectedCuratedCorpusItem } from '@prisma/client';
+import { CuratedStatus, RejectedItem } from '@prisma/client';
 import {
   assertValidSnowplowObjectUpdateEvents,
   getAllSnowplowEvents,
@@ -50,7 +50,7 @@ const approvedItem: ApprovedItem = {
   updatedBy: 'Amy',
 };
 
-const rejectedItem: RejectedCuratedCorpusItem = {
+const rejectedItem: RejectedItem = {
   id: 123,
   externalId: '123-abc',
   prospectId: '456-dfg',

--- a/src/events/snowplow/ReviewedItemSnowplowHandler.ts
+++ b/src/events/snowplow/ReviewedItemSnowplowHandler.ts
@@ -11,7 +11,7 @@ import {
   ReviewedCorpusItem,
 } from './schema';
 import { getUnixTimestamp } from '../../shared/utils';
-import { CuratedStatus, RejectedCuratedCorpusItem } from '@prisma/client';
+import { CuratedStatus, RejectedItem } from '@prisma/client';
 import { CuratedCorpusEventEmitter } from '../curatedCorpusEventEmitter';
 import { CorpusItemSource } from '../../shared/types';
 import { ApprovedItem, ApprovedItemAuthor } from '../../database/types';
@@ -118,7 +118,7 @@ export class ReviewedItemSnowplowHandler extends CuratedCorpusSnowplowHandler {
       );
     } else {
       context = ReviewedItemSnowplowHandler.generateRejectedItemContext(
-        item as RejectedCuratedCorpusItem,
+        item as RejectedItem,
         context
       );
     }
@@ -152,7 +152,7 @@ export class ReviewedItemSnowplowHandler extends CuratedCorpusSnowplowHandler {
   }
 
   private static generateRejectedItemContext(
-    item: RejectedCuratedCorpusItem,
+    item: RejectedItem,
     context: ReviewedCorpusItemContext
   ): ReviewedCorpusItemContext {
     context.data = {

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,5 +1,5 @@
 import {
-  RejectedCuratedCorpusItem,
+  RejectedItem,
   ScheduledItem as ScheduledItemModel,
 } from '@prisma/client';
 import { ScheduledItem, CorpusItem, ApprovedItem } from '../database/types';
@@ -34,7 +34,7 @@ export type BaseEventData = {
 
 // Data for the events that are fired on changes to curated items
 export type ReviewedCorpusItemPayload = {
-  reviewedCorpusItem: ApprovedItem | RejectedCuratedCorpusItem;
+  reviewedCorpusItem: ApprovedItem | RejectedItem;
 };
 
 // Data for the events that are fired on updates to Scheduled Surface schedule

--- a/src/test/helpers/clearDb.integration.ts
+++ b/src/test/helpers/clearDb.integration.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from '@prisma/client';
 import { clearDb } from './clearDb';
 import { createApprovedItemHelper } from './createApprovedItemHelper';
 import { createScheduledItemHelper } from './createScheduledItemHelper';
-import { createRejectedCuratedCorpusItemHelper } from './createRejectedCuratedCorpusItemHelper';
+import { createRejectedItemHelper } from './createRejectedItemHelper';
 
 const db = new PrismaClient();
 
@@ -30,7 +30,7 @@ describe('clearDb', () => {
       approvedItem,
     });
 
-    await createRejectedCuratedCorpusItemHelper(db, {
+    await createRejectedItemHelper(db, {
       title: '7 Life-Saving Tips About PHP',
     });
 
@@ -39,7 +39,7 @@ describe('clearDb', () => {
     expect(items).toHaveLength(2);
     const scheduledItems = await db.scheduledItem.findMany({});
     expect(scheduledItems).toHaveLength(1);
-    const rejectedItems = await db.rejectedCuratedCorpusItem.findMany({});
+    const rejectedItems = await db.rejectedItem.findMany({});
     expect(rejectedItems).toHaveLength(1);
 
     // Remove all the records

--- a/src/test/helpers/clearDb.ts
+++ b/src/test/helpers/clearDb.ts
@@ -10,5 +10,5 @@ export async function clearDb(prisma: PrismaClient): Promise<void> {
   // Delete data from each table, starting with tables that contain foreign keys
   await prisma.scheduledItem.deleteMany({});
   await prisma.approvedItem.deleteMany({});
-  await prisma.rejectedCuratedCorpusItem.deleteMany({});
+  await prisma.rejectedItem.deleteMany({});
 }

--- a/src/test/helpers/createApprovedItemHelper.ts
+++ b/src/test/helpers/createApprovedItemHelper.ts
@@ -59,20 +59,20 @@ export async function createApprovedItemHelper(
     authors: {
       create: authors,
     },
-    status: faker.random.arrayElement([
+    status: faker.helpers.arrayElement([
       CuratedStatus.RECOMMENDATION,
       CuratedStatus.CORPUS,
     ]),
-    language: faker.random.arrayElement(['EN', 'DE']),
+    language: faker.helpers.arrayElement(['EN', 'DE']),
     publisher: faker.company.companyName(),
-    imageUrl: faker.random.arrayElement([
+    imageUrl: faker.helpers.arrayElement([
       `${faker.image.nature()}?random=${random}`,
       `${faker.image.city()}?random=${random}`,
       `${faker.image.food()}?random=${random}`,
     ]),
     // Plain strings for now, but we may be able to consume some sort of enum
     // from a "source of truth" API further down the track.
-    topic: faker.random.arrayElement([
+    topic: faker.helpers.arrayElement([
       'BUSINESS',
       'CAREER',
       'CORONAVIRUS',
@@ -90,7 +90,7 @@ export async function createApprovedItemHelper(
       'TECHNOLOGY',
       'TRAVEL',
     ]),
-    source: faker.random.arrayElement([
+    source: faker.helpers.arrayElement([
       CorpusItemSource.PROSPECT,
       CorpusItemSource.MANUAL,
       CorpusItemSource.BACKFILL,

--- a/src/test/helpers/createRejectedItemHelper.integration.ts
+++ b/src/test/helpers/createRejectedItemHelper.integration.ts
@@ -2,13 +2,13 @@ import { PrismaClient } from '@prisma/client';
 import { expect } from 'chai';
 import { clearDb } from './clearDb';
 import {
-  createRejectedCuratedCorpusItemHelper,
-  CreateRejectedCuratedCorpusItemHelperInput,
-} from './createRejectedCuratedCorpusItemHelper';
+  createRejectedItemHelper,
+  CreateRejectedItemHelperInput,
+} from './createRejectedItemHelper';
 
 const db = new PrismaClient();
 
-describe('createRejectedCuratedCorpusItemHelper', () => {
+describe('createRejectedItemHelper', () => {
   beforeEach(async () => {
     await clearDb(db);
   });
@@ -18,11 +18,11 @@ describe('createRejectedCuratedCorpusItemHelper', () => {
   });
 
   it('creates a rejected item with just the title supplied', async () => {
-    const data: CreateRejectedCuratedCorpusItemHelperInput = {
+    const data: CreateRejectedItemHelperInput = {
       title: 'Never Suffer From PHP Again',
     };
 
-    const item = await createRejectedCuratedCorpusItemHelper(db, data);
+    const item = await createRejectedItemHelper(db, data);
 
     // Expect to see the title we passed to the helper
     expect(item.title).to.equal(data.title);
@@ -37,8 +37,8 @@ describe('createRejectedCuratedCorpusItemHelper', () => {
     expect(item.reason).to.be.not.undefined;
   });
 
-  it('creates a curated item with all properties supplied', async () => {
-    const data: CreateRejectedCuratedCorpusItemHelperInput = {
+  it('creates a rejected item with all properties supplied', async () => {
+    const data: CreateRejectedItemHelperInput = {
       prospectId: 'abc-123',
       url: 'https://www.test.com/',
       title: 'Never Suffer From PHP Again',
@@ -48,7 +48,7 @@ describe('createRejectedCuratedCorpusItemHelper', () => {
       reason: 'unspecified',
     };
 
-    const item = await createRejectedCuratedCorpusItemHelper(db, data);
+    const item = await createRejectedItemHelper(db, data);
 
     // Expect to see everything as specified to the helper
     expect(item).to.deep.include(data);

--- a/src/test/helpers/createRejectedItemHelper.ts
+++ b/src/test/helpers/createRejectedItemHelper.ts
@@ -1,16 +1,12 @@
-import {
-  RejectedCuratedCorpusItem,
-  Prisma,
-  PrismaClient,
-} from '@prisma/client';
+import { RejectedItem, Prisma, PrismaClient } from '@prisma/client';
 import { faker } from '@faker-js/faker';
 // the minimum of data required to create a rejected item
-interface CreateRejectedCuratedCorpusItemHelperRequiredInput {
+interface CreateRejectedItemHelperRequiredInput {
   title: string;
 }
 
 // optional information you can provide when creating a curated item
-interface CreateRejectedCuratedCorpusItemHelperOptionalInput {
+interface CreateRejectedItemHelperOptionalInput {
   prospectId?: string;
   url?: string;
   topic?: string;
@@ -20,35 +16,34 @@ interface CreateRejectedCuratedCorpusItemHelperOptionalInput {
 }
 
 // the input type the helper function expects - a combo of required and optional parameters
-export type CreateRejectedCuratedCorpusItemHelperInput =
-  CreateRejectedCuratedCorpusItemHelperRequiredInput &
-    CreateRejectedCuratedCorpusItemHelperOptionalInput;
+export type CreateRejectedItemHelperInput =
+  CreateRejectedItemHelperRequiredInput & CreateRejectedItemHelperOptionalInput;
 
 /**
  * A helper function that creates a sample curated item for testing or local development.
  * @param prisma
  * @param data
  */
-export async function createRejectedCuratedCorpusItemHelper(
+export async function createRejectedItemHelper(
   prisma: PrismaClient,
-  data: CreateRejectedCuratedCorpusItemHelperInput
-): Promise<RejectedCuratedCorpusItem> {
+  data: CreateRejectedItemHelperInput
+): Promise<RejectedItem> {
   // defaults for optional properties
-  const createRejectedCuratedCorpusItemDefaults = {
+  const createRejectedItemDefaults = {
     prospectId: faker.datatype.uuid(),
     url: faker.internet.url(),
     topic: faker.lorem.words(2),
-    language: faker.random.arrayElement(['EN', 'DE']),
+    language: faker.helpers.arrayElement(['EN', 'DE']),
     publisher: faker.company.companyName(),
     reason: faker.lorem.word(),
     createdAt: faker.date.recent(14),
     createdBy: faker.fake('{{hacker.noun}}|{{internet.email}}'), // imitation auth0 user id
   };
 
-  const inputs: Prisma.RejectedCuratedCorpusItemCreateInput = {
-    ...createRejectedCuratedCorpusItemDefaults,
+  const inputs: Prisma.RejectedItemCreateInput = {
+    ...createRejectedItemDefaults,
     ...data,
   };
 
-  return await prisma.rejectedCuratedCorpusItem.create({ data: inputs });
+  return await prisma.rejectedItem.create({ data: inputs });
 }

--- a/src/test/helpers/createScheduledItemHelper.ts
+++ b/src/test/helpers/createScheduledItemHelper.ts
@@ -37,7 +37,7 @@ export async function createScheduledItemHelper(
   const creatScheduledItemDefaults = {
     createdAt: faker.date.recent(14),
     createdBy: faker.fake('{{hacker.noun}}|{{internet.email}}'), // imitation auth0 user id
-    scheduledDate: faker.random.arrayElement([
+    scheduledDate: faker.helpers.arrayElement([
       faker.date.soon(7).toISOString(),
       faker.date.recent(7).toISOString(),
     ]),

--- a/src/test/helpers/index.ts
+++ b/src/test/helpers/index.ts
@@ -1,5 +1,5 @@
 export { clearDb } from './clearDb';
 export { createApprovedItemHelper } from './createApprovedItemHelper';
 export { createScheduledItemHelper } from './createScheduledItemHelper';
-export { createRejectedCuratedCorpusItemHelper } from './createRejectedCuratedCorpusItemHelper';
+export { createRejectedItemHelper } from './createRejectedItemHelper';
 export { getServerWithMockedHeaders } from './getServerWithMockedHeaders';


### PR DESCRIPTION
### Do Not Merge

Until the corresponding frontend changes are in (PR TBA)

## Goal

Fix a long-running bug in the Curation Admin Tools when occasionally the Prospecting page crashes on fetching prospects.

- Updated GraphQL schema to make `topic`, `publisher`, `title` and `language` fields optional.

- Updated Prisma schema to make `topic` (the only field from the above list that was not yet optional) optional.

- Took this opportunity to rename the Prisma entity and all other references to RejectedItem (was: RejectedCuratedCorpusItem). Updated all tests and helpers.

- Updated some Faker library calls to remove deprecated notices from integration tests.


## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1492