### PR TITLE
feat(rejected items): [BACK-1492] Make fields optional on rejected items

### DIFF
--- a/prisma/migrations/20220829073134_make_topic_optional_for_rejected_items/migration.sql
+++ b/prisma/migrations/20220829073134_make_topic_optional_for_rejected_items/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `RejectedCuratedCorpusItem` MODIFY `topic` VARCHAR(255) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,7 +70,7 @@ model RejectedCuratedCorpusItem {
   prospectId String?  @db.VarChar(255)
   url        String   @db.VarChar(500)
   title      String?  @db.VarChar(255)
-  topic      String   @db.VarChar(255)
+  topic      String?   @db.VarChar(255)
   language   String?  @db.VarChar(2)
   publisher  String?  @db.VarChar(255)
   // Can be multiple reasons. For the MVP, Snowplow and the frontend

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -23,7 +23,7 @@ async function main() {
     const approvedItem = await createApprovedItemHelper(prisma, { title });
 
     await createScheduledItemHelper(prisma, {
-      scheduledSurfaceGuid: faker.random.arrayElement([
+      scheduledSurfaceGuid: faker.helpers.arrayElement([
         'NEW_TAB_EN_US',
         'NEW_TAB_DE_DE',
       ]),

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -231,20 +231,20 @@ type RejectedCorpusItem @key(fields: "url") {
     """
     The title of the story.
     """
-    title: String!
+    title: String
     """
     A topic this story best fits in.
     Temporarily a string value that will be provided by Prospect API, possibly an enum in the future.
     """
-    topic: String!
+    topic: String
     """
     What language this story is in. This is a two-letter code, for example, 'EN' for English.
     """
-    language: CorpusLanguage!
+    language: CorpusLanguage
     """
     The name of the online publication that published this story.
     """
-    publisher: String!
+    publisher: String
     """
     Reason why it was rejected. Can be multiple reasons. Will likely be stored either as comma-separated values or JSON.
     """

--- a/src/test/helpers/createApprovedItemHelper.ts
+++ b/src/test/helpers/createApprovedItemHelper.ts
@@ -59,20 +59,20 @@ export async function createApprovedItemHelper(
     authors: {
       create: authors,
     },
-    status: faker.random.arrayElement([
+    status: faker.helpers.arrayElement([
       CuratedStatus.RECOMMENDATION,
       CuratedStatus.CORPUS,
     ]),
-    language: faker.random.arrayElement(['EN', 'DE']),
+    language: faker.helpers.arrayElement(['EN', 'DE']),
     publisher: faker.company.companyName(),
-    imageUrl: faker.random.arrayElement([
+    imageUrl: faker.helpers.arrayElement([
       `${faker.image.nature()}?random=${random}`,
       `${faker.image.city()}?random=${random}`,
       `${faker.image.food()}?random=${random}`,
     ]),
     // Plain strings for now, but we may be able to consume some sort of enum
     // from a "source of truth" API further down the track.
-    topic: faker.random.arrayElement([
+    topic: faker.helpers.arrayElement([
       'BUSINESS',
       'CAREER',
       'CORONAVIRUS',
@@ -90,7 +90,7 @@ export async function createApprovedItemHelper(
       'TECHNOLOGY',
       'TRAVEL',
     ]),
-    source: faker.random.arrayElement([
+    source: faker.helpers.arrayElement([
       CorpusItemSource.PROSPECT,
       CorpusItemSource.MANUAL,
       CorpusItemSource.BACKFILL,

--- a/src/test/helpers/createRejectedCuratedCorpusItemHelper.ts
+++ b/src/test/helpers/createRejectedCuratedCorpusItemHelper.ts
@@ -38,7 +38,7 @@ export async function createRejectedCuratedCorpusItemHelper(
     prospectId: faker.datatype.uuid(),
     url: faker.internet.url(),
     topic: faker.lorem.words(2),
-    language: faker.random.arrayElement(['EN', 'DE']),
+    language: faker.helpers.arrayElement(['EN', 'DE']),
     publisher: faker.company.companyName(),
     reason: faker.lorem.word(),
     createdAt: faker.date.recent(14),

--- a/src/test/helpers/createScheduledItemHelper.ts
+++ b/src/test/helpers/createScheduledItemHelper.ts
@@ -37,7 +37,7 @@ export async function createScheduledItemHelper(
   const creatScheduledItemDefaults = {
     createdAt: faker.date.recent(14),
     createdBy: faker.fake('{{hacker.noun}}|{{internet.email}}'), // imitation auth0 user id
-    scheduledDate: faker.random.arrayElement([
+    scheduledDate: faker.helpers.arrayElement([
       faker.date.soon(7).toISOString(),
       faker.date.recent(7).toISOString(),
     ]),


### PR DESCRIPTION
# DO NOT MERGE

Until the corresponding frontend changes are ready to be merged, too: https://github.com/Pocket/curation-admin-tools/pull/943

## Goal

Fix a long-running bug in the Curation Admin Tools when occasionally the Prospecting page crashes on fetching prospects.

- Updated GraphQL schema to make topic, publisher, title and language fields optional.

 - Updated Prisma schema to make topic (the only field from the above list that was not yet optional) optional.

- Updated some Faker library calls to remove deprecated notices from integration tests.


## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1492