### PR TITLE
feat(prospecting): [INFRA-965] Add new prospecting source (TOP_SAVED) to New Tab (US)

### DIFF
--- a/.github/workflows/snowplow/schemas.json
+++ b/.github/workflows/snowplow/schemas.json
@@ -6,13 +6,13 @@
         "vendor": "com.pocket",
         "name": "object_update",
         "format": "jsonschema",
-        "version": "1-0-5"
+        "version": "1-0-9"
       },
       {
         "vendor": "com.pocket",
         "name": "reviewed_corpus_item",
         "format": "jsonschema",
-        "version": "1-0-1"
+        "version": "1-0-4"
       },
       {
         "vendor": "com.pocket",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -40,6 +40,7 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
     guid: 'NEW_TAB_EN_US',
     ianaTimezone: 'America/New_York',
     prospectTypes: [
+      ProspectType.TOP_SAVED,
       ProspectType.GLOBAL,
       ProspectType.ORGANIC_TIMESPENT,
       ProspectType.SYNDICATED_NEW,


### PR DESCRIPTION
## Goal

Add a new prospecting source to the New Tab (US) surface as requested by the data products team. This source is already available for the Pocket Hits (US) surface. 

Similar to the Pocket Hits surfaces, I placed this source on top of the list in the API code. However, on the frontend, the sources are listed alphabetically, so this new source turns up on the list last (see screenshot below).

Additionally, the Snowplow schema check is failing for all PRs in this repository (`Invalid api key`). This won't fix it, but I thought I'd update the schema versions all the same - two out of three were well behind the current version.

![topsaved_frontend](https://user-images.githubusercontent.com/22447785/215029144-ab804ba3-2fa9-4a9e-bc51-605c70e6c4cf.png)

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/INFRA-965
