### PR TITLE
Updated CI Setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,12 @@ orbs:
   aws-ecs: circleci/aws-ecs@2.2.1
   pocket: pocket/circleci-orbs@1.2.8
 
+parameters:
+  cache-version:
+    default: node-v2
+    description: "Version prefix for the cache name, primarily for node_modules caching in this pipeline."
+    type: string
+
 # Workflow shortcuts
 not_main: &not_main
   filters:
@@ -46,7 +52,7 @@ only_dev: &only_dev
 jobs:
   apollo:
     docker:
-      - image: cimg/node:current@sha256:60048477384ccd5c594740396d743d2296e0dd637eafa4a80dc51612fd779b41
+      - image: node:16@sha256:496085d0cd8edf49c97ec86ac11bed85b6f965d9b29885887bb0edba26549b07
     steps:
       - checkout
       - run:
@@ -105,7 +111,7 @@ jobs:
 
   build:
     docker:
-      - image: cimg/node:current@sha256:60048477384ccd5c594740396d743d2296e0dd637eafa4a80dc51612fd779b41
+      - image: node:16@sha256:496085d0cd8edf49c97ec86ac11bed85b6f965d9b29885887bb0edba26549b07
     steps:
       - checkout
       # Define the working directory for this job
@@ -113,24 +119,20 @@ jobs:
           at: /tmp/workspace
       - restore_cache:
           keys:
-            # when lock file changes, use increasingly general patterns to restore cache
-            # If this gets our of sync, you can increment the version (vX).  Just be
-            # sure to match that version when saving the cache as well.
-            - node-v1-{{ checksum "package-lock.json" }}
-            - node-v1-
+            - <<pipeline.parameters.cache-version>>-{{ checksum "package-lock.json" }}-{{ checksum "prisma/schema.prisma" }}
       - run:
           name: install node modules
           command: npm ci
       # Save the cache to avoid extraneous downloads
       - save_cache:
-          key: node-v1-{{ checksum "package-lock.json" }}
+          key: <<pipeline.parameters.cache-version>>-{{ checksum "package-lock.json" }}-{{ checksum "prisma/schema.prisma" }}
           paths:
             - ./node_modules
       - run:
           name: generate prisma client
           command: npm run db:generate-client
       - run:
-          name:
+          name: run build
           command: |
             export NODE_ENV=production
             npm run build
@@ -153,7 +155,7 @@ jobs:
         description: 'Integration tests'
         type: string
     docker:
-      - image: cimg/node:current@sha256:60048477384ccd5c594740396d743d2296e0dd637eafa4a80dc51612fd779b41
+      - image: node:16@sha256:496085d0cd8edf49c97ec86ac11bed85b6f965d9b29885887bb0edba26549b07
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -188,17 +190,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            # when lock file changes, use increasingly general patterns to restore cache
-            # If this gets our of sync, you can increment the version (vX).  Just be
-            # sure to match that version when saving the cache as well.
-            - node-v1-{{ checksum "package-lock.json" }}
-            - node-v1-
+            - <<pipeline.parameters.cache-version>>-{{ checksum "package-lock.json" }}-{{ checksum "prisma/schema.prisma" }}
       - run:
           name: install node modules
-          command: npm install
+          command: npm ci
       # Save the cache to avoid extraneous downloads
       - save_cache:
-          key: node-v1-{{ checksum "package-lock.json" }}
+          key: <<pipeline.parameters.cache-version>>-{{ checksum "package-lock.json" }}-{{ checksum "prisma/schema.prisma" }}
           paths:
             - ./node_modules
       - run:
@@ -210,6 +208,7 @@ jobs:
           command: |
             export $(egrep -v '^#' .docker/local.env | xargs -0)
             npm run migrate:reset -- --skip-seed --force
+            ./node_modules/.bin/prisma --version
             << parameters.command >>
 
 

--- a/.circleci/scripts/setup.sh
+++ b/.circleci/scripts/setup.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+apt-get update && apt-get install -y sudo
+
 dir=$(dirname "$0")
 while [[ "$1" ]]; do
    case "$1" in

--- a/.circleci/scripts/setup_db.sh
+++ b/.circleci/scripts/setup_db.sh
@@ -3,7 +3,7 @@
 
 echo "Setting up database"
 
-sudo apt-get update && sudo apt-get install -y mysql-client
+sudo apt-get update && sudo apt-get install -y default-mysql-client
 
 set -e
 mysql=( mysql -uroot -h127.0.0.1 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,22 @@
 version: '3.1'
 services:
+  tests:
+    image: node:16@sha256:496085d0cd8edf49c97ec86ac11bed85b6f965d9b29885887bb0edba26549b07
+    entrypoint: /bin/bash
+    env_file:
+      - .docker/local.env
+    environment:
+      - LOCALSTACK_HOST=localstack
+      - NODE_ENV=test
+    tty: true
+    volumes:
+      - ./:/app
+    working_dir: /app
+    depends_on:
+      - mysql
+      - localstack
+      - snowplow
+
   mysql:
     image: mysql:5.7@sha256:0e3435e72c493aec752d8274379b1eac4d634f47a7781a7a92b8636fa1dc94c1
     platform: linux/amd64


### PR DESCRIPTION
Ticket: None, came up in context of CI fails on #830 

What this PR does:
* updates caching strategy in CircleCI to keep cache aligned with changes in packages & prisma config changes
* changes the CI steps for testing, builds to run on the same base image that the application itself is built upon & run within - to avoid differences in deployed environments & CI of OS-level requirements, like openssl versions installed