### PR TITLE
feat(saved): allow access to curated info on list

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -110,6 +110,18 @@ type Query {
     surface(id: ID!): Surface!
 }
 
+extend type SavedItem  @key(fields: "givenUrl") {
+    """
+    key field to identify the SavedItem entity in the ListApi service
+    """
+    givenUrl: Url! @external
+
+    """
+    If the item is in corpus allow the saved item to reference it.  Exposing curated info for consistent UX
+    """
+    corpusItem: CorpusItem @requires(fields: "givenUrl")
+}
+
 # Commented out until RecsAPI implements the fields that lets us extend Recommendation
 #extend type Recommendation  @key(fields: "corpusItemId") {
 #    """

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -110,11 +110,11 @@ type Query {
     surface(id: ID!): Surface!
 }
 
-extend type SavedItem @key(fields: "givenUrl") {
+type SavedItem @key(fields: "url") {
     """
     key field to identify the SavedItem entity in the ListApi service
     """
-    givenUrl: Url! @external
+    url: Url! @external
 
     """
     If the item is in corpus allow the saved item to reference it.  Exposing curated info for consistent UX

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -114,7 +114,7 @@ type SavedItem @key(fields: "url") {
     """
     key field to identify the SavedItem entity in the ListApi service
     """
-    url: Url! @external
+    url: String! @external
 
     """
     If the item is in corpus allow the saved item to reference it.  Exposing curated info for consistent UX

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -110,7 +110,7 @@ type Query {
     surface(id: ID!): Surface!
 }
 
-extend type SavedItem  @key(fields: "givenUrl") {
+extend type SavedItem @key(fields: "givenUrl") {
     """
     key field to identify the SavedItem entity in the ListApi service
     """
@@ -119,7 +119,7 @@ extend type SavedItem  @key(fields: "givenUrl") {
     """
     If the item is in corpus allow the saved item to reference it.  Exposing curated info for consistent UX
     """
-    corpusItem: CorpusItem @requires(fields: "givenUrl")
+    corpusItem: CorpusItem
 }
 
 # Commented out until RecsAPI implements the fields that lets us extend Recommendation

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,7 +1,7 @@
 import { DateResolver } from 'graphql-scalars';
 import { getScheduledSurface } from './queries/ScheduledSurface';
 import { getItemsForScheduledSurface } from './queries/ScheduledSurfaceItem';
-import { getCorpusItem } from './queries/CorpusItem';
+import { getCorpusItem, getSavedCorpusItem } from './queries/CorpusItem';
 
 export const resolvers = {
   // The Date resolver enforces the date to be in the YYYY-MM-DD format.
@@ -16,7 +16,7 @@ export const resolvers = {
   },
   // Allow the `SavedItem` to resolve the corpus item
   SavedItem: {
-    corpusItem: getCorpusItem,
+    corpusItem: getSavedCorpusItem,
   },
   Query: {
     // Gets the metadata for a Scheduled Surface (for example, New Tab).

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -14,6 +14,10 @@ export const resolvers = {
   CorpusItem: {
     __resolveReference: getCorpusItem,
   },
+  // Allow the `SavedItem` to resolve the corpus item
+  SavedItem: {
+    corpusItem: getCorpusItem,
+  },
   Query: {
     // Gets the metadata for a Scheduled Surface (for example, New Tab).
     scheduledSurface: getScheduledSurface,

--- a/src/public/resolvers/queries/CorpusItem.integration.ts
+++ b/src/public/resolvers/queries/CorpusItem.integration.ts
@@ -88,13 +88,15 @@ describe('CorpusItem reference resolver', () => {
 
     expect(result.data).to.not.be.null;
     expect(result.data?._entities).to.have.lengthOf(1);
-    expect(result.data?._entities[0].title).to.equal(approvedItem.title);
-    expect(result.data?._entities[0].authors).to.have.lengthOf(
+    expect(result.data?._entities[0].corpusItem.title).to.equal(
+      approvedItem.title
+    );
+    expect(result.data?._entities[0].corpusItem.authors).to.have.lengthOf(
       <number>approvedItem.authors?.length
     );
   });
 
-  it('should throw an error if the url provided is not known', async () => {
+  it('should return null if the url provided is not known', async () => {
     const result = await server.executeOperation({
       query: CORPUS_ITEM_REFERENCE_RESOLVER,
       variables: {
@@ -107,12 +109,8 @@ describe('CorpusItem reference resolver', () => {
       },
     });
 
-    // There should be errors
-    expect(result.errors).not.to.be.null;
-
-    expect(result.errors?.[0].message).to.contain(
-      `Could not find Corpus Item with Url of "ABRACADABRA"`
-    );
-    expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
+    expect(result.errors).to.be.null;
+    expect(result.data?._entities).to.have.lengthOf(1);
+    expect(result.data?._entities[0]).to.be.null;
   });
 });

--- a/src/public/resolvers/queries/CorpusItem.integration.ts
+++ b/src/public/resolvers/queries/CorpusItem.integration.ts
@@ -65,4 +65,55 @@ describe('CorpusItem reference resolver', () => {
     );
     expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
   });
+
+
+  it('returns the corpus item if it exists', async () => {
+    // Create an approved item.
+    const approvedItem = await createApprovedItemHelper(db, {
+      title: 'Story one',
+    });
+
+    const result = await server.executeOperation({
+      query: CORPUS_ITEM_REFERENCE_RESOLVER,
+      variables: {
+        representations: [
+          {
+            __typename: 'SavedItem',
+            givenUrl: approvedItem.url,
+          },
+        ],
+      },
+    });
+
+    expect(result.errors).to.be.undefined;
+
+    expect(result.data).to.not.be.null;
+    expect(result.data?._entities).to.have.lengthOf(1);
+    expect(result.data?._entities[0].title).to.equal(approvedItem.title);
+    expect(result.data?._entities[0].authors).to.have.lengthOf(
+      <number>approvedItem.authors?.length
+    );
+  });
+
+  it('should throw an error if the url provided is not known', async () => {
+    const result = await server.executeOperation({
+      query: CORPUS_ITEM_REFERENCE_RESOLVER,
+      variables: {
+        representations: [
+          {
+            __typename: 'SavedItem',
+            givenUrl: 'ABRACADABRA',
+          },
+        ],
+      },
+    });
+
+    // There should be errors
+    expect(result.errors).not.to.be.null;
+
+    expect(result.errors?.[0].message).to.contain(
+      `Could not find Corpus Item with Url of "ABRACADABRA"`
+    );
+    expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
+  });
 });

--- a/src/public/resolvers/queries/CorpusItem.integration.ts
+++ b/src/public/resolvers/queries/CorpusItem.integration.ts
@@ -109,8 +109,8 @@ describe('CorpusItem reference resolver', () => {
       },
     });
 
-    expect(result.errors).to.be.null;
+    expect(result.errors).to.be.undefined;
     expect(result.data?._entities).to.have.lengthOf(1);
-    expect(result.data?._entities[0]).to.be.null;
+    expect(result.data?._entities[0].corpusItem).to.be.null;
   });
 });

--- a/src/public/resolvers/queries/CorpusItem.integration.ts
+++ b/src/public/resolvers/queries/CorpusItem.integration.ts
@@ -66,7 +66,6 @@ describe('CorpusItem reference resolver', () => {
     expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
   });
 
-
   it('returns the corpus item if it exists', async () => {
     // Create an approved item.
     const approvedItem = await createApprovedItemHelper(db, {
@@ -79,7 +78,7 @@ describe('CorpusItem reference resolver', () => {
         representations: [
           {
             __typename: 'SavedItem',
-            givenUrl: approvedItem.url,
+            url: approvedItem.url,
           },
         ],
       },
@@ -102,7 +101,7 @@ describe('CorpusItem reference resolver', () => {
         representations: [
           {
             __typename: 'SavedItem',
-            givenUrl: 'ABRACADABRA',
+            url: 'ABRACADABRA',
           },
         ],
       },

--- a/src/public/resolvers/queries/CorpusItem.ts
+++ b/src/public/resolvers/queries/CorpusItem.ts
@@ -1,5 +1,8 @@
 import { CorpusItem } from '../../../database/types';
-import { getApprovedItemByExternalId, getApprovedItemByUrl } from '../../../database/queries/ApprovedItem';
+import {
+  getApprovedItemByExternalId,
+  getApprovedItemByUrl,
+} from '../../../database/queries/ApprovedItem';
 import { getCorpusItemFromApprovedItem } from '../../../shared/utils';
 import { UserInputError } from 'apollo-server-errors';
 
@@ -10,11 +13,16 @@ import { UserInputError } from 'apollo-server-errors';
  * @param db
  */
 export async function getCorpusItem(item, { db }): Promise<CorpusItem> {
-  const { id, givenUrl } = item;
+  const { id, url } = item;
 
-  const approvedItem = id ? await getApprovedItemByExternalId(db, id) : await getApprovedItemByUrl(db, givenUrl)
+  const approvedItem = id
+    ? await getApprovedItemByExternalId(db, id)
+    : await getApprovedItemByUrl(db, url);
   if (!approvedItem) {
-    if(givenUrl) throw new UserInputError(`Could not find Corpus Item with Url of "${givenUrl}"`)
+    if (url)
+      throw new UserInputError(
+        `Could not find Corpus Item with Url of "${url}"`
+      );
     throw new UserInputError(`Could not find Corpus Item with ID of "${id}".`);
   }
 

--- a/src/public/resolvers/queries/CorpusItem.ts
+++ b/src/public/resolvers/queries/CorpusItem.ts
@@ -32,7 +32,6 @@ export async function getSavedCorpusItem(
 
   const approvedItem = await getApprovedItemByUrl(db, url);
   if (!approvedItem) {
-    console.log(`Could not find Corpus Item with Url of "${url}"`);
     return null;
   }
 

--- a/src/public/resolvers/queries/CorpusItem.ts
+++ b/src/public/resolvers/queries/CorpusItem.ts
@@ -13,17 +13,29 @@ import { UserInputError } from 'apollo-server-errors';
  * @param db
  */
 export async function getCorpusItem(item, { db }): Promise<CorpusItem> {
-  const { id, url } = item;
+  const { id } = item;
 
-  const approvedItem = id
-    ? await getApprovedItemByExternalId(db, id)
-    : await getApprovedItemByUrl(db, url);
+  const approvedItem = await getApprovedItemByExternalId(db, id);
   if (!approvedItem) {
-    if (url)
-      throw new UserInputError(
-        `Could not find Corpus Item with Url of "${url}"`
-      );
+    return null;
+
     throw new UserInputError(`Could not find Corpus Item with ID of "${id}".`);
+  }
+
+  return getCorpusItemFromApprovedItem(approvedItem);
+}
+
+export async function getSavedCorpusItem(
+  item,
+  args,
+  { db }
+): Promise<CorpusItem> {
+  const { url } = item;
+
+  const approvedItem = await getApprovedItemByUrl(db, url);
+  if (!approvedItem) {
+    console.log(`Could not find Corpus Item with Url of "${url}"`);
+    return null;
   }
 
   return getCorpusItemFromApprovedItem(approvedItem);

--- a/src/public/resolvers/queries/CorpusItem.ts
+++ b/src/public/resolvers/queries/CorpusItem.ts
@@ -17,8 +17,6 @@ export async function getCorpusItem(item, { db }): Promise<CorpusItem> {
 
   const approvedItem = await getApprovedItemByExternalId(db, id);
   if (!approvedItem) {
-    return null;
-
     throw new UserInputError(`Could not find Corpus Item with ID of "${id}".`);
   }
 

--- a/src/public/resolvers/queries/CorpusItem.ts
+++ b/src/public/resolvers/queries/CorpusItem.ts
@@ -1,5 +1,5 @@
 import { CorpusItem } from '../../../database/types';
-import { getApprovedItemByExternalId } from '../../../database/queries/ApprovedItem';
+import { getApprovedItemByExternalId, getApprovedItemByUrl } from '../../../database/queries/ApprovedItem';
 import { getCorpusItemFromApprovedItem } from '../../../shared/utils';
 import { UserInputError } from 'apollo-server-errors';
 
@@ -10,10 +10,11 @@ import { UserInputError } from 'apollo-server-errors';
  * @param db
  */
 export async function getCorpusItem(item, { db }): Promise<CorpusItem> {
-  const { id } = item;
+  const { id, givenUrl } = item;
 
-  const approvedItem = await getApprovedItemByExternalId(db, id);
+  const approvedItem = id ? await getApprovedItemByExternalId(db, id) : await getApprovedItemByUrl(db, givenUrl)
   if (!approvedItem) {
+    if(givenUrl) throw new UserInputError(`Could not find Corpus Item with Url of "${givenUrl}"`)
     throw new UserInputError(`Could not find Corpus Item with ID of "${id}".`);
   }
 

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -50,18 +50,13 @@ export const CORPUS_ITEM_REFERENCE_RESOLVER = gql`
           name
         }
       }
-    }
-  }
-`;
-
-export const CORPUS_ITEM_SAVED_ITEM_REFERENCE_RESOLVER = gql`
-  query ($representations: [_Any!]!) {
-    _entities(representations: $representations) {
-      ... on CorpusItem {
-        id
-        title
-        authors {
-          name
+      ... on SavedItem {
+        corpusItem {
+          id
+          title
+          authors {
+            name
+          }
         }
       }
     }

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -53,3 +53,17 @@ export const CORPUS_ITEM_REFERENCE_RESOLVER = gql`
     }
   }
 `;
+
+export const CORPUS_ITEM_SAVED_ITEM_REFERENCE_RESOLVER = gql`
+  query ($representations: [_Any!]!) {
+    _entities(representations: $representations) {
+      ... on CorpusItem {
+        id
+        title
+        authors {
+          name
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Goal
Allow curated info to be available to saved items so we may create a consistent UX across surfaces.

- Create a connection for saved item by url


## I'd love feedback/perspectives on:
Everything!

## Implementation Decisions
Curated info is not available to saved items.  This creates opportunity for a confusion user experience because an item they save from one of our surfaces may end up being representing in an entirely different way once it gets to the save surface.  As we move down the path of blurring the lines between these surfaces with things like lists, it is important that we have the most relevant and consistent data available.

Here is a rather visceral example.

![2023-01-31 17 09 13](https://user-images.githubusercontent.com/16119672/215920345-fbe046b0-a927-419c-b207-5073a4a0b1f7.gif)