### PR TITLE
fix(target): updating resolver for target type

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -90,6 +90,9 @@ type CorpusItem @key(fields: "id") {
     """
     topic: String
 
+    """
+    If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).
+    """
     target: CorpusTarget
 }
 

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -164,6 +164,7 @@ export type CorpusTargetType = 'SyndicatedArticle' | 'Collection';
 
 export type CorpusTarget = {
   slug: string;
+  __typename: CorpusTargetType;
 };
 
 // Types for the public `scheduledSurface` query.

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -2,8 +2,6 @@ import { DateResolver } from 'graphql-scalars';
 import { getScheduledSurface } from './queries/ScheduledSurface';
 import { getItemsForScheduledSurface } from './queries/ScheduledSurfaceItem';
 import { getCorpusItem, getSavedCorpusItem } from './queries/CorpusItem';
-import { getPocketPath } from '../../shared/utils';
-import { CorpusTargetType } from '../../database/types';
 
 export const resolvers = {
   // The Date resolver enforces the date to be in the YYYY-MM-DD format.
@@ -23,14 +21,5 @@ export const resolvers = {
   Query: {
     // Gets the metadata for a Scheduled Surface (for example, New Tab).
     scheduledSurface: getScheduledSurface,
-  },
-  CorpusTarget: {
-    __resolveType({ url }, contextValue, info): CorpusTargetType {
-      if (url) {
-        return getPocketPath(url)?.type;
-      }
-
-      return null;
-    },
   },
 };

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -62,3 +62,25 @@ export const CORPUS_ITEM_REFERENCE_RESOLVER = gql`
     }
   }
 `;
+
+export const CORPUS_ITEM_TARGET_REFERENCE_RESOLVER = gql`
+  query ($representations: [_Any!]!) {
+    _entities(representations: $representations) {
+      ... on CorpusItem {
+        id
+        title
+        target {
+          __typename
+
+          ... on Collection {
+            slug
+          }
+
+          ... on SyndicatedArticle {
+            slug
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -108,6 +108,7 @@ export const getCorpusItemFromApprovedItem = (
     topic: approvedItem.topic ?? undefined,
     target: target?.key && {
       slug: target.key,
+      __typename: target.type,
     },
   };
 };


### PR DESCRIPTION
## Goal

Fix https://sentry.io/organizations/pocket/issues/3911297928/?project=5938284&query=is%3Aunresolved&referrer=issue-stream

Turns out that the main type (in this case CorpusTarget) comes into resolveType, and we are already defining the CorpusTarget slug elsewhere, we just needed to pass the type name with it.
