### PR TITLE
feat(reference): adding a url based reference resolver for CorpusItem

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -46,7 +46,7 @@ union CorpusTarget = SyndicatedArticle | Collection
 Represents an item that is in the Corpus and its associated manually edited metadata.
 TODO: CorpusItem to implement PocketResource when it becomes available.
 """
-type CorpusItem @key(fields: "id") {
+type CorpusItem @key(fields: "id") @key(fields: "url") {
     """
     The GUID that is stored on an approved corpus item
     """

--- a/src/public/resolvers/queries/CorpusItem.integration.ts
+++ b/src/public/resolvers/queries/CorpusItem.integration.ts
@@ -16,7 +16,7 @@ describe('CorpusItem reference resolver', () => {
     await server.stop();
   });
 
-  it('returns the corpus item if it exists', async () => {
+  it('returns the corpus item if it exists by reference resolver id', async () => {
     // Create an approved item.
     const approvedItem = await createApprovedItemHelper(db, {
       title: 'Story one',
@@ -44,7 +44,7 @@ describe('CorpusItem reference resolver', () => {
     );
   });
 
-  it('should throw an error if the id provided is not known', async () => {
+  it('should return null if the reference resolver id provided is not known', async () => {
     const result = await server.executeOperation({
       query: CORPUS_ITEM_REFERENCE_RESOLVER,
       variables: {
@@ -57,13 +57,59 @@ describe('CorpusItem reference resolver', () => {
       },
     });
 
-    // There should be errors
-    expect(result.errors).not.to.be.null;
+    // The entity should be null
+    expect(result.errors).to.be.undefined;
+    expect(result.data).to.not.be.null;
+    expect(result.data?._entities).to.have.lengthOf(1);
+    expect(result.data?._entities[0]).to.be.null;
+  });
 
-    expect(result.errors?.[0].message).to.contain(
-      `Could not find Corpus Item with ID of "ABRACADABRA"`
+  it('returns the corpus item if it exists by reference resolver url', async () => {
+    // Create an approved item.
+    const approvedItem = await createApprovedItemHelper(db, {
+      title: 'Story one',
+    });
+
+    const result = await server.executeOperation({
+      query: CORPUS_ITEM_REFERENCE_RESOLVER,
+      variables: {
+        representations: [
+          {
+            __typename: 'CorpusItem',
+            url: approvedItem.url,
+          },
+        ],
+      },
+    });
+
+    expect(result.errors).to.be.undefined;
+
+    expect(result.data).to.not.be.null;
+    expect(result.data?._entities).to.have.lengthOf(1);
+    expect(result.data?._entities[0].title).to.equal(approvedItem.title);
+    expect(result.data?._entities[0].authors).to.have.lengthOf(
+      <number>approvedItem.authors?.length
     );
-    expect(result.errors?.[0].extensions?.code).to.equal('BAD_USER_INPUT');
+  });
+
+  it('should return null if the reference resolver url provided is not known', async () => {
+    const result = await server.executeOperation({
+      query: CORPUS_ITEM_REFERENCE_RESOLVER,
+      variables: {
+        representations: [
+          {
+            __typename: 'CorpusItem',
+            url: 'ABRACADABRA',
+          },
+        ],
+      },
+    });
+
+    // The entity should be null
+    expect(result.errors).to.be.undefined;
+    expect(result.data).to.not.be.null;
+    expect(result.data?._entities).to.have.lengthOf(1);
+    expect(result.data?._entities[0]).to.be.null;
   });
 
   it('returns the corpus item if it exists', async () => {

--- a/src/public/resolvers/queries/CorpusItem.ts
+++ b/src/public/resolvers/queries/CorpusItem.ts
@@ -7,17 +7,18 @@ import { getCorpusItemFromApprovedItem } from '../../../shared/utils';
 import { UserInputError } from 'apollo-server-errors';
 
 /**
- * Pulls in approved corpus items for a given id.
+ * Pulls in approved corpus items for a given id or url.
  *
- * @param item
+ * @param item { id, url }
  * @param db
  */
-export async function getCorpusItem(item, { db }): Promise<CorpusItem> {
-  const { id } = item;
+export async function getCorpusItem({ id, url }, { db }): Promise<CorpusItem> {
+  const approvedItem = id
+    ? await getApprovedItemByExternalId(db, id)
+    : await getApprovedItemByUrl(db, url);
 
-  const approvedItem = await getApprovedItemByExternalId(db, id);
   if (!approvedItem) {
-    throw new UserInputError(`Could not find Corpus Item with ID of "${id}".`);
+    return null;
   }
 
   return getCorpusItemFromApprovedItem(approvedItem);


### PR DESCRIPTION
## Goal

Setting up a url reference resolver that will be used to allow CorpusItem to be resolved by it's URL. This will be used on https://github.com/Pocket/list-api/pull/630 which will let clients know if the corpus item has been saved to the user's list.
