### PR TITLE
feat(CorpusLanguage): [INFRA-1017] Adding Italian, French, Spanish langauges to CorpusLanguage enum

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - HOSTNAME_EXTERNAL=localstack
 
   app:
-    image: node:16@sha256:27fab5920246070cf13449cf44c25bc4f5adef18ca7482b2bda90b7cf9e64481
+    image: node:18@sha256:370db2cf5b89acc950805ef32aa9cbfc69d86769f92ba9f3492a36a6f75e0d92
     platform: linux/amd64
     env_file:
       - .docker/local.env

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -26,7 +26,7 @@ scalar NonNegativeInt
 """
 Valid language codes for curated corpus items.
 """
-enum CorpusLanguage @shareable {
+enum CorpusLanguage {
     "German"
     DE
     "English"

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -20,7 +20,7 @@ scalar NonNegativeInt
 """
 Valid language codes for curated corpus items.
 """
-enum CorpusLanguage {
+enum CorpusLanguage @shareable {
     "German"
     DE
     "English"

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -1,8 +1,8 @@
 extend schema
-  @link(
-    url: "https://specs.apollo.dev/federation/v2.0"
-    import: ["@key", "@shareable", "@requires", "@external"]
-  )
+    @link(
+        url: "https://specs.apollo.dev/federation/v2.0"
+        import: ["@key", "@shareable", "@requires", "@external"]
+    )
 
 """
 A URL - usually, for an interesting story on the internet that's worth saving to Pocket.
@@ -25,6 +25,12 @@ enum CorpusLanguage {
     DE
     "English"
     EN
+    "Italian"
+    IT
+    "French"
+    FR
+    "Spanish"
+    ES
 }
 
 """

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -1,7 +1,13 @@
 extend schema
     @link(
         url: "https://specs.apollo.dev/federation/v2.0"
-        import: ["@key", "@shareable", "@requires", "@external"]
+        import: [
+            "@key"
+            "@shareable"
+            "@requires"
+            "@external"
+            "@inaccessible"
+        ]
     )
 
 """
@@ -26,11 +32,11 @@ enum CorpusLanguage @shareable {
     "English"
     EN
     "Italian"
-    IT
+    IT @inaccessible
     "French"
-    FR
+    FR @inaccessible
     "Spanish"
-    ES
+    ES @inaccessible
 }
 
 """

--- a/src/admin/resolvers/mutations/ApprovedItem.integration.ts
+++ b/src/admin/resolvers/mutations/ApprovedItem.integration.ts
@@ -582,6 +582,86 @@ describe('mutations: ApprovedItem', () => {
         'does not exist in "CorpusLanguage" enum.'
       );
     });
+
+    it('should succeed if language code (English) is correct and upper case', async () => {
+      input.language = 'EN';
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_APPROVED_ITEM),
+          variables: { data: input },
+        });
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(result.body.errors).to.be.undefined;
+      const data = result.body.data;
+      expect(data.updateApprovedCorpusItem.language).to.equal('EN');
+    });
+
+    it('should succeed if language code (Deutsch) is correct and upper case', async () => {
+      input.language = 'DE';
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_APPROVED_ITEM),
+          variables: { data: input },
+        });
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(result.body.errors).to.be.undefined;
+      const data = result.body.data;
+      expect(data.updateApprovedCorpusItem.language).to.equal('DE');
+    });
+
+    it('should succeed if language code (Italian) is correct and upper case', async () => {
+      input.language = 'IT';
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_APPROVED_ITEM),
+          variables: { data: input },
+        });
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(result.body.errors).to.be.undefined;
+      const data = result.body.data;
+      expect(data.updateApprovedCorpusItem.language).to.equal('IT');
+    });
+
+    it('should succeed if language code (Spanish) is correct and upper case', async () => {
+      input.language = 'ES';
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_APPROVED_ITEM),
+          variables: { data: input },
+        });
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(result.body.errors).to.be.undefined;
+      const data = result.body.data;
+      expect(data.updateApprovedCorpusItem.language).to.equal('ES');
+    });
+
+    it('should succeed if language code (French) is correct and upper case', async () => {
+      input.language = 'FR';
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_APPROVED_ITEM),
+          variables: { data: input },
+        });
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(result.body.errors).to.be.undefined;
+      const data = result.body.data;
+      expect(data.updateApprovedCorpusItem.language).to.equal('FR');
+    });
   });
 
   describe('updateApprovedCorpusAuthorsItem mutation', () => {

--- a/src/admin/resolvers/mutations/RejectedItem.integration.ts
+++ b/src/admin/resolvers/mutations/RejectedItem.integration.ts
@@ -412,5 +412,85 @@ describe('mutations: RejectedItem', () => {
         'does not exist in "CorpusLanguage" enum.'
       );
     });
+
+    it('should succeed if language code (English) is correct and upper case', async () => {
+      input.language = 'EN';
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_REJECTED_ITEM),
+          variables: { data: input },
+        });
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(result.body.errors).to.be.undefined;
+      const data = result.body.data;
+      expect(data.createRejectedCorpusItem.language).to.equal('EN');
+    });
+
+    it('should succeed if language code (Deutsch) is correct and upper case', async () => {
+      input.language = 'DE';
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_REJECTED_ITEM),
+          variables: { data: input },
+        });
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(result.body.errors).to.be.undefined;
+      const data = result.body.data;
+      expect(data.createRejectedCorpusItem.language).to.equal('DE');
+    });
+
+    it('should succeed if language code (Italian) is correct and upper case', async () => {
+      input.language = 'IT';
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_REJECTED_ITEM),
+          variables: { data: input },
+        });
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(result.body.errors).to.be.undefined;
+      const data = result.body.data;
+      expect(data.createRejectedCorpusItem.language).to.equal('IT');
+    });
+
+    it('should succeed if language code (Spanish) is correct and upper case', async () => {
+      input.language = 'ES';
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_REJECTED_ITEM),
+          variables: { data: input },
+        });
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(result.body.errors).to.be.undefined;
+      const data = result.body.data;
+      expect(data.createRejectedCorpusItem.language).to.equal('ES');
+    });
+
+    it('should succeed if language code (French) is correct and upper case', async () => {
+      input.language = 'FR';
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_REJECTED_ITEM),
+          variables: { data: input },
+        });
+      // Good to check for any errors before proceeding with the rest of the test
+      expect(result.body.errors).to.be.undefined;
+      const data = result.body.data;
+      expect(data.createRejectedCorpusItem.language).to.equal('FR');
+    });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,6 @@ initItemEventHandlers(curatedCorpusEventEmitter, [
 
 (async () => {
   const { adminUrl, publicUrl } = await startServer(4025);
-  console.log(`🚀 Public server ready at http://localhost:4004${publicUrl}`);
-  console.log(`🚀 Admin server ready at http://localhost:4004${adminUrl}`);
+  console.log(`🚀 Public server ready at http://localhost:4025${publicUrl}`);
+  console.log(`🚀 Admin server ready at http://localhost:4025${adminUrl}`);
 })();


### PR DESCRIPTION
## Goal

Adding Italian, Spanish and French languages to `CorpusLanguage` enum. Adding some more testing around this.
Updated docker-compose to use node18 for app container.

## Implementation

Adding the new language enum values under the `@inaccessible` directive. Once deployed, I will do a staggered deploy on the **prospect-api** side. 

This aligns with the what the docs mention for this directive: https://www.apollographql.com/docs/federation/federated-types/federated-directives/#inaccessible

This needs to be merged into prod first for the **prospect-api** PR apollo checks to pass. Since our `apollo` CircleCI orb only checks against the prod federated graph. I deployed both services to dev to test but need to tweak the orb for that first.


## JIRA ticket:
* [https://getpocket.atlassian.net/browse/INFRA-1017](https://getpocket.atlassian.net/browse/INFRA-1017)