### PR TITLE
feat(synchecks): add basic synchecks for graphql, server

### DIFF
--- a/.aws/package-lock.json
+++ b/.aws/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@pocket-tools/terraform-modules": "4.14.0"
+        "@pocket-tools/terraform-modules": "^4.16.1"
       },
       "devDependencies": {
         "@pocket-tools/eslint-config": "2.0.0",
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@pocket-tools/terraform-modules": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@pocket-tools/terraform-modules/-/terraform-modules-4.14.0.tgz",
-      "integrity": "sha512-A7B97z0LNTycS9XEftuVH4rnW5OTVzTC1/3z9uVE1Jw3rTso6NACngzmhSA1d26Jlk9aI26Vbpr5VqiMW340kw==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@pocket-tools/terraform-modules/-/terraform-modules-4.16.1.tgz",
+      "integrity": "sha512-Y/wwPz2OoWQYCeS00ivfj547DNl0jCUDZTkvqCFg8XJBpmR1ZVJyl6ZqFdquscqqYlOXpDjx5cPpcPKiuCleQg==",
       "dependencies": {
         "@cdktf/provider-archive": "4.0.0",
         "@cdktf/provider-aws": "11.0.9",
@@ -845,7 +845,7 @@
         "parse-domain": "^4.1.0"
       },
       "engines": {
-        "node": ">=16.18"
+        "node": ">=16.20"
       }
     },
     "node_modules/@pocket-tools/tsconfig": {

--- a/.aws/package.json
+++ b/.aws/package.json
@@ -18,7 +18,7 @@
     "node": ">=16"
   },
   "dependencies": {
-    "@pocket-tools/terraform-modules": "4.14.0"
+    "@pocket-tools/terraform-modules": "^4.16.1"
   },
   "devDependencies": {
     "@pocket-tools/eslint-config": "2.0.0",

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -15,6 +15,7 @@ import { config } from './config';
 import {
   ApplicationRDSCluster,
   PocketALBApplication,
+  PocketAwsSyntheticChecks,
   PocketECSCodePipeline,
   PocketPagerDuty,
   PocketVPC,
@@ -28,10 +29,9 @@ class CuratedCorpusAPI extends TerraformStack {
     super(scope, name);
 
     new AwsProvider(this, 'aws', { region: 'us-east-1' });
-
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
     new LocalProvider(this, 'local_provider');
     new NullProvider(this, 'null_provider');
+    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
 
     new RemoteBackend(this, {
       hostname: 'app.terraform.io',
@@ -39,14 +39,15 @@ class CuratedCorpusAPI extends TerraformStack {
       workspaces: [{ prefix: `${config.name}-` }],
     });
 
-    const pocketVpc = new PocketVPC(this, 'pocket-vpc');
-    const region = new DataAwsRegion(this, 'region');
     const caller = new DataAwsCallerIdentity(this, 'caller');
+    const region = new DataAwsRegion(this, 'region');
+    const pocketVpc = new PocketVPC(this, 'pocket-vpc');
+    const curatedCorpusPagerduty = this.createPagerDuty();
 
     const pocketApp = this.createPocketAlbApplication({
       rds: this.createRds(pocketVpc),
       s3: this.createS3Bucket(),
-      pagerDuty: this.createPagerDuty(),
+      pagerDuty: curatedCorpusPagerduty,
       secretsManagerKmsAlias: this.getSecretsManagerKmsAlias(),
       snsTopic: this.getCodeDeploySnsTopic(),
       region,
@@ -54,6 +55,38 @@ class CuratedCorpusAPI extends TerraformStack {
     });
 
     this.createApplicationCodePipeline(pocketApp);
+
+    new PocketAwsSyntheticChecks(this, 'synthetics', {
+      // alarmTopicArn: config.environment === 'Prod' ? curatedCorpusPagerduty.snsCriticalAlarmTopic.arn : '', // this should be improved, empty string recreates updates constantly as is in cdktf
+      alarmTopicArn: '', // remove this line & uncomment above line when we're ready to alert on synchecks
+      environment: process.env.NODE_ENV === 'development' ? 'Dev' : 'Prod', // yes we should use config.environment, but needs more refinment in module
+      prefix: config.prefix,
+      query: [
+        {
+          endpoint: config.domain,
+          data: '{"query": "query {scheduledSurface(id: \\"NEW_TAB_EN_US\\"){id}}"}', // New Tab relies upon scheduledSurface query
+          jmespath: 'data.scheduledSurface.id',
+          response: 'NEW_TAB_EN_US',
+        },
+        {
+          endpoint: config.domain,
+          data: '{"query": "query { scheduledSurface(id: \\"NEW_TAB_EN_US\\") {items(date: \\"2023-05-30\\") {corpusItem {id, url}}}}"}', // New Tab also relies upon corpusItem resolution
+          jmespath:
+            'to_string(length(data.scheduledSurface.items[*].corpusItem.id))',
+          response: `${config.environment === 'Prod' ? '25' : '2'}`,
+        },
+      ],
+      securityGroupIds: pocketVpc.defaultSecurityGroups.ids,
+      shortName: config.shortName,
+      subnetIds: pocketVpc.privateSubnetIds,
+      tags: config.tags,
+      uptime: [
+        {
+          response: 'ok',
+          url: `${config.domain}/.well-known/apollo/server-health`, // is the express server up?
+        },
+      ],
+    });
   }
 
   /**

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -63,14 +63,7 @@ class CuratedCorpusAPI extends TerraformStack {
       prefix: config.prefix,
       query: [
         {
-          // New Tab relies upon scheduledSurface query
-          endpoint: config.domain,
-          data: '{"query": "query {scheduledSurface(id: \\"NEW_TAB_EN_US\\"){id}}"}',
-          jmespath: 'data.scheduledSurface.id',
-          response: 'NEW_TAB_EN_US',
-        },
-        {
-          // New Tab also relies upon corpusItem resolution
+          // New Tab relies upon scheduledSurface query & upon corpusItem resolution
           endpoint: config.domain,
           data: '{"query": "query { scheduledSurface(id: \\"NEW_TAB_EN_US\\") {items(date: \\"2023-05-30\\") {corpusItem {id, url}}}}"}',
           jmespath:


### PR DESCRIPTION
Jira ticket: https://getpocket.atlassian.net/browse/INFRA-1276

**What this PR does:**
Adds some synthetic checks, using baseline of reusable code from monitoring "project" work, for sake of monitoring curated corpus api better in service of New Tab.

**Why this PR:**
New Tab is ... going live? Doing something important this week <New Tab folks to fill in>. As part of this, they requested that all services New Tab depends on are better supported operationally ASAP. Alas, Curated Corpus API's operational ownership falls currently to Backend.

As part of trying to be at least a little bit more prepared operationally, this PR adds a few synthetic checks to better monitor deployed Curated Corpus API codepaths that are vital for New Tab: the scheduledSurface Query, and something to do with resolving CorpusItem-typed resources. Plus we should be aware if the express server is up or not.

**The synthetics added:**
* check if the express server is up or not just pinging the healthcheck & validating the response body & response code (directly, inside the VPC, not getting messed up if Client API fails for some reason - this is true of all these synthetics);
* POST a scheduledsurface query & parse & validate the graphql response (to make sure that query is working);
* Ensure same scheduledSurface query POST returns resolved items & CorpusItems, validating the graphql response lengths for returned corpusItem.ids is non-null (to make sure the CorpusItem resolution is working);

**Questions about these:**
* ~is this the best way to check the fitness of these Graphql resources & operations per how New Tab uses this service? I'm just guessing at the most obvious paths~; conferred with Nina & Jonathan independently on this and made adjustments accordingly.
* ~it appears that the curated corpus database does not remove items from the ScheduledItem table in the curated corpus database (dev & prod) once the scheduledDate pasts - giving me something to validate resolution on. Please tell me if this is incorrect though, primarily for prod (if dev alerts, it won't page, it'll just be red, so I care a little less).~ Confirmed items in database shouldn't be removed after date passes.
* I'm not validating exact ids returned for scheduledItem table values since I don't trust the sort order will remain consistent. If we trust the order of CorpusItem.ids returned is sorted consistently, we could validate specific id values instead of number of ids returned.

**Next Steps:**

- [x] get this into dev and validate - already done, dev is working fine
- [ ] get this into prod without alerting / paging hooked up & validate - will occur after this PR goes in
- [ ] make a second PR that enables alerting based on these synthetics 
- [ ] update https://getpocket.atlassian.net/wiki/spaces/PE/pages/2561343516/Curated+Corpus+API to match the service doc template, including reliability docs, links to alerting & metrics, etc. - so we can know whats expected of this service going forward