### PR TITLE
feat(synchecks): enable critical (tier 1) alerting on prod synchecks

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -57,8 +57,10 @@ class CuratedCorpusAPI extends TerraformStack {
     this.createApplicationCodePipeline(pocketApp);
 
     new PocketAwsSyntheticChecks(this, 'synthetics', {
-      // alarmTopicArn: config.environment === 'Prod' ? curatedCorpusPagerduty.snsCriticalAlarmTopic.arn : '', // this should be improved, empty string recreates updates constantly as is in cdktf
-      alarmTopicArn: '', // remove this line & uncomment above line when we're ready to alert on synchecks
+      alarmTopicArn:
+        config.environment === 'Prod'
+          ? curatedCorpusPagerduty.snsCriticalAlarmTopic.arn
+          : '', // this should be improved, empty string recreates updates constantly as is in cdktf
       environment: process.env.NODE_ENV === 'development' ? 'Dev' : 'Prod', // yes we should use config.environment, but needs more refinment in module
       prefix: config.prefix,
       query: [


### PR DESCRIPTION
Enable tier 1 / critical alerting for the production synthetic checks, as they've been pushed to prod and appear to work as desired.

Related service & reliability docs: https://getpocket.atlassian.net/wiki/spaces/PE/pages/2561343516/Curated+Corpus+API

Closes out #908 & related ticket.