### PR TITLE
Chore/mc 45 prisma logging

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -210,7 +210,6 @@ class CuratedCorpusAPI extends TerraformStack {
 
     return new PocketALBApplication(this, 'application', {
       internal: true,
-
       prefix: config.prefix,
       alb6CharacterPrefix: config.shortName,
       tags: config.tags,

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -216,8 +216,8 @@ class CuratedCorpusAPI extends TerraformStack {
       cdn: false,
       domain: config.domain,
       taskSize: {
-          cpu: 4096,
-          memory: 16384,
+        cpu: 4096,
+        memory: 16384,
       },
       containerConfigs: [
         {

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -210,6 +210,7 @@ class CuratedCorpusAPI extends TerraformStack {
 
     return new PocketALBApplication(this, 'application', {
       internal: true,
+
       prefix: config.prefix,
       alb6CharacterPrefix: config.shortName,
       tags: config.tags,
@@ -245,6 +246,10 @@ class CuratedCorpusAPI extends TerraformStack {
             {
               name: 'AWS_REGION',
               value: region.name,
+            },
+            {
+              name: 'DEBUG',
+              value: 'prisma:client,prisma:engine',
             },
           ],
           logGroup: this.createCustomLogGroup('app'),

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -216,6 +216,10 @@ class CuratedCorpusAPI extends TerraformStack {
       tags: config.tags,
       cdn: false,
       domain: config.domain,
+      taskSize: {
+          cpu: 4096,
+          memory: 16384,
+      },
       containerConfigs: [
         {
           name: 'app',


### PR DESCRIPTION
## Goal
- Add Prisma logging such that we get more information in the Sentry breadcrums when exceptions happen.
- Increase task size, both to see if this alleviates the issue (however unlikely) and to handle potentially increased CPU load from logging (which is probably minimal).

## Implementation Decisions
- I first looked into catching the exception and logging additional data. However, I don't think we'd learn much more from that. All data in [PrismaClientUnknownRequestError](https://github.com/prisma/prisma/blob/main/packages/client/src/runtime/core/errors/PrismaClientUnknownRequestError.ts) is already logged, and we can infer the query parameters from the [request variables logged to Sentry](https://pocket.sentry.io/issues/4402959030/?project=5938284&query=scheduledItem&referrer=issue-stream&sort=freq&statsPeriod=7d&stream_index=4#extra). The SQL queries run successfully when we reconstruct them and run them against the database.
- Logging both from Prisma client and engine. :shrug: 

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/MC-45

Documentation:
* https://www.prisma.io/docs/concepts/components/prisma-client/debugging
