### PR TITLE
fix(RDS): Increase minCapacity on production from 1 to 2

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -15,7 +15,7 @@ const snowplowEndpoint = isDev
   : 'com-getpocket-prod1.collector.snplow.net';
 
 const rds = {
-  minCapacity: 1,
+  minCapacity: isDev ? 1 : 2,
   maxCapacity: isDev ? 1 : undefined,
 };
 


### PR DESCRIPTION
## Goal
Experiment with increasing Aurora capacity, to see if it fixes errors from Prisma:
- [Timed out fetching a new connection from the connection pool.](https://pocket.sentry.io/issues/4397585063/?query=start%3D2023-08-19T08%3A57%3A00%26end%3D2023-08-19T23%3A40%3A53%26groupStatsPeriod%3Dauto&referrer=alerts-related-issues-issue-stream) More info: http://pris.ly/d/connection-pool (Current connection pool timeout: 10, connection limit: 5)
- [Incorrect arguments to mysqld_stmt_execute](https://pocket.sentry.io/issues/4397585063/?query=start%3D2023-08-19T08%3A57%3A00%26end%3D2023-08-19T23%3A41%3A42%26groupStatsPeriod%3Dauto&referrer=alerts-related-issues-issue-stream)

Both of these errors spiked immediately after a scale-in event from 2 to 1 capacity units on Aurora Serverless.

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/MC-46

Documentation:
* [Choosing the minimum Aurora Serverless v2 capacity setting for a cluster](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html#aurora-serverless-v2.min_capacity_considerations) (Not sure if any of these recommendations apply to us.)
