### PR TITLE
fix(Database): [MC-57] Increase connection limit

### DIFF
--- a/.docker/local.env
+++ b/.docker/local.env
@@ -12,6 +12,7 @@ AWS_XRAY_LOG_LEVEL=silent
 
 # Database
 DATABASE_URL=mysql://root:@mysql:3306/curation_corpus?connect_timeout=300
+MODIFIED_DATABASE_URL=mysql://root:@mysql:3306/curation_corpus?connect_timeout=300&connection_count=10
 
 # Snowplow
 SNOWPLOW_ENDPOINT=snowplow:9090

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,10 @@ ENV GIT_SHA=${GIT_SHA}
 
 EXPOSE ${PORT}
 
-CMD ["npm", "start"]
+# Override the connection on the database_url, to avoid
+# "Timed out fetching a new connection from the connection pool"
+# https://www.prisma.io/docs/guides/performance-and-optimization/connection-management#increasing-the-pool-size
+# Aurora Serverless has a connection limit of 2,000:
+# https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html
+# Value of 50 was chosen arbitrarily because it is 10x the original value of 5.
+CMD sh -c 'export MODIFIED_DATABASE_URL="${DATABASE_URL}?connection_limit=50" && npm start'

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,7 @@ generator client {
 
 datasource db {
   provider = "mysql"
-  url      = env("DATABASE_URL")
+  url      = env("MODIFIED_DATABASE_URL")
 }
 
 model ApprovedItemAuthor {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -21,6 +21,14 @@ if (!awsEnvironments.includes(process.env.NODE_ENV ?? '')) {
 const snowplowHttpProtocol =
   process.env.NODE_ENV === 'production' ? 'https' : 'http';
 
+// Override the connection on the database_url, to avoid
+// "Timed out fetching a new connection from the connection pool"
+// https://www.prisma.io/docs/guides/performance-and-optimization/connection-management#increasing-the-pool-size
+// Aurora Serverless has a connection limit of 2,000:
+// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html
+// Value of 50 was chosen arbitrarily because it is 10x the original value of 5.
+process.env.MODIFIED_DATABASE_URL = `${process.env.DATABASE_URL}?connection_limit=50`;
+
 // Environment variables below are set in .aws/src/main.ts
 export default {
   app: {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -21,14 +21,6 @@ if (!awsEnvironments.includes(process.env.NODE_ENV ?? '')) {
 const snowplowHttpProtocol =
   process.env.NODE_ENV === 'production' ? 'https' : 'http';
 
-// Override the connection on the database_url, to avoid
-// "Timed out fetching a new connection from the connection pool"
-// https://www.prisma.io/docs/guides/performance-and-optimization/connection-management#increasing-the-pool-size
-// Aurora Serverless has a connection limit of 2,000:
-// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html
-// Value of 50 was chosen arbitrarily because it is 10x the original value of 5.
-process.env.MODIFIED_DATABASE_URL = `${process.env.DATABASE_URL}?connection_limit=50`;
-
 // Environment variables below are set in .aws/src/main.ts
 export default {
   app: {

--- a/src/test/setup/jest.setup.js
+++ b/src/test/setup/jest.setup.js
@@ -15,6 +15,7 @@ module.exports = async () => {
   process.env.DATABASE_URL =
     process.env.DATABASE_URL ??
     'mysql://root:@localhost:3306/curation_corpus?connect_timeout=300';
+  process.env.MODIFIED_DATABASE_URL = process.env.DATABASE_URL;
   process.env.SNOWPLOW_ENDPOINT =
     process.env.SNOWPLOW_ENDPOINT ?? 'localhost:9090';
   require('dotenv').config({ path: '../../../.docker/local.env' });


### PR DESCRIPTION
## Goal
Fix [a Prisma timeout error](https://pocket.sentry.io/issues/4397585063/events/4e49d852464441048eeb4295859302cc/?environment=production&project=5938284&query=is%3Aunresolved+timeout&referrer=next-event&statsPeriod=7d&stream_index=0) that occurs about once per day, since August 15th, in the hope that this reduces curated-corpus-api database outages.

> Timed out fetching a new connection from the connection pool. More info: http://pris.ly/d/connection-pool (Current connection pool timeout: 10, connection limit: 5)

## QA
- [x] Deployed and tested in dev environment

## I'd love feedback/perspectives on:
Is this approach too hacky? 

## Implementation Decisions
I wanted to experiment to see if increasing the pool size fixes our outages with this database. The approach I chose is probably not the best one, but I didn't want to invest a lot of effort if it wouldn't make a difference. Alternative approaches I considered:
  - Modify terraform-modules to accept url arguments to append to the database url. Probably the cleanest solution, if possible?
  - Change the CDKTF code in this repo, to create a new secret with a modified `DATABASE_URL`. (Not sure if that's even possible.)
  - Set an environment variable in the application on startup. Tried this. Didn't work, probably because Prisma Client runs in a different shell.
  - Increase ECS task CPU count even further. More CPU = more connections. We're already fairly high at 4096.

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/MC-57

Documentation:
* [AWS docs on determining the max number of connections](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v1.how-it-works.html#aurora-serverless.max-connections)
* [Prisma docs on how to increase the connection pool size](https://www.prisma.io/docs/guides/performance-and-optimization/connection-management#increasing-the-pool-size)
