### PR TITLE
Enable prisma query logging

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -251,8 +251,8 @@ class CuratedCorpusAPI extends TerraformStack {
               value: region.name,
             },
             {
-              name: 'DEBUG',
-              value: 'prisma:client,prisma:engine',
+              name: 'LOG_LEVEL',
+              value: 'debug',
             },
           ],
           logGroup: this.createCustomLogGroup('app'),


### PR DESCRIPTION
## Goal
Enable prisma query logging

## I'd love feedback/perspectives on:
-  Did I get it right

## Implementation Decisions

Because we use the event model for prisma client, all queries are sent to our Winston logging instance. These are delivered as 'debug' log level. The correct way to enable query logging for this app is to set the log level to debug.

```
export function client(): PrismaClient {
  if (prisma) return prisma;

  prisma = new PrismaClient({
    log: [
      {
        level: 'error',
        emit: 'event',
      },
      {
        level: 'warn',
        emit: 'event',
      },
      {
        level: 'info',
        emit: 'event',
      },
      {
        level: 'query',
        emit: 'event',
      },
    ],
  });

  prisma.$on('error', (e) => {
    e.source = 'prisma';
    serverLogger.error(e);
  });

  prisma.$on('warn', (e) => {
    e.source = 'prisma';
    serverLogger.warn(e);
  });

  prisma.$on('info', (e) => {
    e.source = 'prisma';
    serverLogger.info(e);
  });

  prisma.$on('query', (e) => {
    e.source = 'prisma';
    serverLogger.debug(e);
  });

  return prisma;
}
```
