### PR TITLE
Revert "feat(Database): enable prisma query logging (#997)"

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -251,8 +251,8 @@ class CuratedCorpusAPI extends TerraformStack {
               value: region.name,
             },
             {
-              name: 'LOG_LEVEL',
-              value: 'debug',
+              name: 'DEBUG',
+              value: 'prisma:client,prisma:engine',
             },
           ],
           logGroup: this.createCustomLogGroup('app'),


### PR DESCRIPTION
## Goal
This reverts commit ba5f8d6b1acf3546bd17f4654c5e348d468b012e.

It appears that https://github.com/Pocket/curated-corpus-api/pull/997 accidentally disables all logging. I tested this locally, but should have tested it in our dev environment.

## Implementation Decisions
My guess is that changing `debug` to `DEBUG` might fix the issue, but I'd rather test this in dev first.