### PR TITLE
chore: lower dev min task count from 4 to 1

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -330,7 +330,7 @@ class CuratedCorpusAPI extends TerraformStack {
           'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
       },
       autoscalingConfig: {
-        targetMinCapacity: 4,
+        targetMinCapacity: config.isDev ? 1 : 4,
         targetMaxCapacity: 10,
       },
       alarms: {


### PR DESCRIPTION
## Goal
Save cost and emissions by lowering the number of tasks running in our Dev environment.

## References

[Slack thread](https://mozilla.slack.com/archives/C05UHBNS1HV/p1697572493007419)
