### PR TITLE
Added new RSS feed content prospecting type

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -80,6 +80,7 @@ enum ProspectType {
     TIMESPENT_MODELED
     TITLE_URL_MODELED
     DISMISSED
+    RSS_LOGISTIC
 }
 
 """

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,6 +12,7 @@ export enum ProspectType {
   TIMESPENT_MODELED = 'TIMESPENT_MODELED',
   TITLE_URL_MODELED = 'TITLE_URL_MODELED',
   DISMISSED = 'DISMISSED',
+  RSS_LOGISTIC = 'RSS_LOGISTIC',
 }
 
 export enum MozillaAccessGroup {
@@ -55,6 +56,7 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.COUNTS_MODELED,
       ProspectType.TIMESPENT_MODELED,
       ProspectType.TITLE_URL_MODELED,
+      ProspectType.RSS_LOGISTIC,
     ],
     accessGroup: MozillaAccessGroup.NEW_TAB_CURATOR_ENUS,
   },
@@ -127,6 +129,7 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.DISMISSED,
       ProspectType.COUNTS_MODELED,
       ProspectType.TITLE_URL_MODELED,
+      ProspectType.RSS_LOGISTIC,
     ],
     accessGroup: MozillaAccessGroup.POCKET_HITS_CURATOR_ENUS,
   },


### PR DESCRIPTION
This is for https://mozilla-hub.atlassian.net/browse/MC-144 

We are adding a new prospecting source for the curators for US new tab and pocket hits

Related PRs
https://github.com/Pocket/dl-metaflow-jobs/pull/227 and https://github.com/Pocket/prospect-api/pull/566