### PR TITLE
Change default ACLs for image upload public bucket

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -24,6 +24,7 @@ import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
 import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
 import { S3Bucket } from '@cdktf/provider-aws/lib/s3-bucket';
 import { S3BucketPublicAccessBlock } from '@cdktf/provider-aws/lib/s3-bucket-public-access-block';
+import { S3BucketOwnershipControls } from '@cdktf/provider-aws/lib/s3-bucket-ownership-controls';
 
 import { CloudwatchLogGroup } from '@cdktf/provider-aws/lib/cloudwatch-log-group';
 
@@ -130,7 +131,18 @@ class CuratedCorpusAPI extends TerraformStack {
         restrictPublicBuckets: false,
       }
     );
+    const ownershipControls = new S3BucketOwnershipControls(
+      this,
+      `${bucket_name}_ownership_controls`,
+      {
+        bucket: bucket.id,
+        rule: {
+          objectOwnership: 'ObjectWriter',
+        },
+      }
+    );
     bucket_with_public_acls.overrideLogicalId(bucket_name);
+    ownershipControls.overrideLogicalId(bucket_name);
     return bucket;
   }
 

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -23,6 +23,8 @@ import {
 import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
 import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
 import { S3Bucket } from '@cdktf/provider-aws/lib/s3-bucket';
+import { S3BucketPublicAccessBlock } from '@cdktf/provider-aws/lib/s3-bucket-public-access-block';
+
 import { CloudwatchLogGroup } from '@cdktf/provider-aws/lib/cloudwatch-log-group';
 
 class CuratedCorpusAPI extends TerraformStack {
@@ -113,9 +115,22 @@ class CuratedCorpusAPI extends TerraformStack {
    * @private
    */
   private createS3Bucket() {
-    return new S3Bucket(this, 'image-uploads', {
-      bucket: `pocket-${config.prefix.toLowerCase()}-images`,
+    const bucket_name = `pocket-${config.prefix.toLowerCase()}-images`;
+    const bucket = new S3Bucket(this, 'image-uploads', {
+      bucket: bucket_name,
     });
+    const bucket_with_public_acls = new S3BucketPublicAccessBlock(
+    this,
+    `${bucket_name}_access_block`,
+    {
+      blockPublicAcls: false,
+      blockPublicPolicy: false,
+      bucket: bucket.id,
+      ignorePublicAcls: false,
+      restrictPublicBuckets: false,
+    });
+    bucket_with_public_acls.overrideLogicalId(bucket_name);
+    return bucket;
   }
 
   /**

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -120,15 +120,16 @@ class CuratedCorpusAPI extends TerraformStack {
       bucket: bucket_name,
     });
     const bucket_with_public_acls = new S3BucketPublicAccessBlock(
-    this,
-    `${bucket_name}_access_block`,
-    {
-      blockPublicAcls: false,
-      blockPublicPolicy: false,
-      bucket: bucket.id,
-      ignorePublicAcls: false,
-      restrictPublicBuckets: false,
-    });
+      this,
+      `${bucket_name}_access_block`,
+      {
+        blockPublicAcls: false,
+        blockPublicPolicy: false,
+        bucket: bucket.id,
+        ignorePublicAcls: false,
+        restrictPublicBuckets: false,
+      }
+    );
     bucket_with_public_acls.overrideLogicalId(bucket_name);
     return bucket;
   }


### PR DESCRIPTION
Previously per object ACL access defaulted to 'on' for new s3 buckets, but at some point that changed.

https://mozilla-hub.atlassian.net/browse/MC-230

Due to a bucket re-creation, the Dev environment bucket has no permissions for public image hosting, causing the 'add to corpus' feature to no longer work on Dev.

This was tested by pushing to dev and it didn't seem to re-create the bucket -- it modified the permissions. Prod push for this PR should be monitored.