### PR TITLE
feat(OGExcerpt): [MC-318] Add rss_logistic_recent prospect type to new_tab_en_us

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -81,6 +81,7 @@ enum ProspectType {
     TITLE_URL_MODELED
     DISMISSED
     RSS_LOGISTIC
+    RSS_LOGISTIC_RECENT
 }
 
 """
@@ -970,5 +971,5 @@ type CorpusItem @key(fields: "url") {
 }
 
 type OpenGraphFields {
-  description: String!
+    description: String!
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -13,6 +13,7 @@ export enum ProspectType {
   TITLE_URL_MODELED = 'TITLE_URL_MODELED',
   DISMISSED = 'DISMISSED',
   RSS_LOGISTIC = 'RSS_LOGISTIC',
+  RSS_LOGISTIC_RECENT = 'RSS_LOGISTIC_RECENT',
 }
 
 export enum MozillaAccessGroup {
@@ -57,6 +58,7 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.TIMESPENT_MODELED,
       ProspectType.TITLE_URL_MODELED,
       ProspectType.RSS_LOGISTIC,
+      ProspectType.RSS_LOGISTIC_RECENT,
     ],
     accessGroup: MozillaAccessGroup.NEW_TAB_CURATOR_ENUS,
   },


### PR DESCRIPTION
## Goal
Add the new `RSS_LOGISTIC_RECENT` prospect type to `NEW_TAB_EN_US` surface for the new tab recent content experiment.

Will be merged before this [PR](https://github.com/Pocket/prospect-api/pull/572).

JIRA ticket:
* [MC-318](https://mozilla-hub.atlassian.net/browse/MC-318)

[MC-318]: https://mozilla-hub.atlassian.net/browse/MC-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ