### PR TITLE
feat(prospectType): [MC-403] Add CONSTRAINT_SCHEDULE

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -82,6 +82,7 @@ enum ProspectType {
     DISMISSED
     RSS_LOGISTIC
     RSS_LOGISTIC_RECENT
+    CONSTRAINT_SCHEDULE
 }
 
 """

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,5 @@
 // Pocket Shared Data - see Confluence for details
-// https://getpocket.atlassian.net/wiki/spaces/PE/pages/2584150049/Pocket+Shared+Data
+// https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390642851/Pocket+Shared+Data#Prospect-Types
 export enum ProspectType {
   TIMESPENT = 'TIMESPENT',
   COUNTS = 'COUNTS',
@@ -14,6 +14,7 @@ export enum ProspectType {
   DISMISSED = 'DISMISSED',
   RSS_LOGISTIC = 'RSS_LOGISTIC',
   RSS_LOGISTIC_RECENT = 'RSS_LOGISTIC_RECENT',
+  CONSTRAINT_SCHEDULE = 'CONSTRAINT_SCHEDULE',
 }
 
 export enum MozillaAccessGroup {
@@ -59,6 +60,7 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.TITLE_URL_MODELED,
       ProspectType.RSS_LOGISTIC,
       ProspectType.RSS_LOGISTIC_RECENT,
+      ProspectType.CONSTRAINT_SCHEDULE,
     ],
     accessGroup: MozillaAccessGroup.NEW_TAB_CURATOR_ENUS,
   },


### PR DESCRIPTION
## Goal
Add new prospect type CONSTRAINT_SCHEDULE, which is a set of prospects without using the same topics and publishers too many times.

## Implementation Decisions
I looked at https://github.com/Pocket/curated-corpus-api/commit/cada3f610bde0961d58208756b30ed2e197416f2 to see which changes need to be made.

## Deployment steps
Deploy this PR before making the change in curation-admin-tools.

## References

JIRA ticket:
- [MC-403](https://mozilla-hub.atlassian.net/browse/MC-403)

Related PRs:
- https://github.com/Pocket/prospect-api/pull/574
- https://github.com/Pocket/dl-metaflow-jobs/pull/250